### PR TITLE
Improvements to video cap negotiations APIs

### DIFF
--- a/desktop_source/desktop_media_manager.h
+++ b/desktop_source/desktop_media_manager.h
@@ -37,11 +37,9 @@ class DesktopMediaManager : public wds::SourceMediaManager {
   std::pair<int,int> GetSinkRtpPorts() const override;
   int GetLocalRtpPort() const override;
 
-  std::vector<wds::SelectableH264VideoFormat> GetSelectableH264VideoFormats() const override;
-  bool InitOptimalVideoFormat(
-      const wds::NativeVideoFormat& sink_native_format,
-      const std::vector<wds::SelectableH264VideoFormat>& sink_supported_formats) override;
-  wds::SelectableH264VideoFormat GetOptimalVideoFormat() const override;
+  bool InitOptimalVideoFormat(const wds::NativeVideoFormat& sink_native_format,
+      const std::vector<wds::H264VideoCodec>& sink_supported_codecs) override;
+  wds::H264VideoFormat GetOptimalVideoFormat() const override;
   bool InitOptimalAudioFormat(const std::vector<wds::AudioCodec>& sink_supported_codecs) override;
   wds::AudioCodec GetOptimalAudioFormat() const override;
   void SendIDRPicture() override;
@@ -51,7 +49,7 @@ class DesktopMediaManager : public wds::SourceMediaManager {
   std::unique_ptr<MiracGstTestSource> gst_pipeline_;
   int sink_port1_;
   int sink_port2_;
-  wds::SelectableH264VideoFormat format_;
+  wds::H264VideoFormat format_;
 };
 
 #endif // DESKTOP_MEDIA_MANAGER_H_

--- a/libwds/common/CMakeLists.txt
+++ b/libwds/common/CMakeLists.txt
@@ -4,4 +4,4 @@ set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -std=c99 -Wall")
 include_directories ("${PROJECT_SOURCE_DIR}" )
 
 add_library(wdscommon OBJECT
-    message_handler.cpp rtsp_input_handler.cpp source_media_manager.cpp)
+    message_handler.cpp rtsp_input_handler.cpp video_format.cpp)

--- a/libwds/public/media_manager.h
+++ b/libwds/public/media_manager.h
@@ -124,13 +124,13 @@ class SinkMediaManager : public MediaManager {
    * Returns list of supported H264 video formats
    * @return vector of supported H264 video formats
    */
-  virtual std::vector<SupportedH264VideoFormats> GetSupportedH264VideoFormats() const = 0;
+  virtual std::vector<H264VideoCodec> GetSupportedH264VideoCodecs() const = 0;
 
   /**
    * Returns native video format of a device
    * @return native video format
    */
-  virtual NativeVideoFormat GetSupportedNativeVideoFormat() const = 0;
+  virtual NativeVideoFormat GetNativeVideoFormat() const = 0;
 
   /**
    * Sets optimal H264 format that would be used to send / receive video stream
@@ -138,7 +138,7 @@ class SinkMediaManager : public MediaManager {
    * @param optimal H264 format
    * @return true if format can be used by media manager, false otherwise
    */
-  virtual bool SetOptimalVideoFormat(const SelectableH264VideoFormat& optimal_format) = 0;
+  virtual bool SetOptimalVideoFormat(const H264VideoFormat& optimal_format) = 0;
 };
 
 /**
@@ -180,12 +180,6 @@ class SourceMediaManager : public MediaManager {
   virtual int GetLocalRtpPort() const = 0;
 
   /**
-   * Returns list of supported H264 video formats
-   * @return vector of supported H264 video formats
-   */
-  virtual std::vector<SelectableH264VideoFormat> GetSelectableH264VideoFormats() const = 0;
-
-  /**
    * Initializes optimal video format
    * The optimal video format will be returned by GetOptimalVideoFormat
    *
@@ -195,14 +189,14 @@ class SourceMediaManager : public MediaManager {
    */
   virtual bool InitOptimalVideoFormat(
       const NativeVideoFormat& sink_native_format,
-      const std::vector<SelectableH264VideoFormat>& sink_supported_formats) = 0;
+      const std::vector<H264VideoCodec>& sink_supported_codecs) = 0;
 
   /**
    * Gets optimal H264 format @see InitOptimalVideoFormat
    *
    * @return optimal H264 format
    */
-  virtual SelectableH264VideoFormat GetOptimalVideoFormat() const = 0;
+  virtual H264VideoFormat GetOptimalVideoFormat() const = 0;
 
   /**
    * Initializes optimal audio codec
@@ -234,20 +228,6 @@ inline SourceMediaManager* ToSourceMediaManager(MediaManager* mng) {
 inline SinkMediaManager* ToSinkMediaManager(MediaManager* mng) {
   return static_cast<SinkMediaManager*>(mng);
 }
-
-/**
- * An auxiliary function to find the optimal format for streaming.
- * The quality selection algorithm will pick codec with higher bandwidth.
- *
- * @param native format of a remote device
- * @param local_formats of H264 formats that are supported by local device
- * @param remote_formats of H264 formats that are supported by remote device
- * @return optimal H264 video format
- */
-WDS_EXPORT SelectableH264VideoFormat FindOptimalVideoFormat(
-    const NativeVideoFormat& remote_device_native_format,
-    std::vector<SelectableH264VideoFormat> local_formats,
-    std::vector<SelectableH264VideoFormat> remote_formats);
 
 }  // namespace wds
 

--- a/libwds/public/video_format.h
+++ b/libwds/public/video_format.h
@@ -22,11 +22,15 @@
 #ifndef VIDEO_FORMAT_H_
 #define VIDEO_FORMAT_H_
 
+#include <bitset>
 #include <vector>
+
+#include "wds_export.h"
 
 namespace wds {
 
-typedef unsigned RateAndResolution;
+using RateAndResolution = unsigned;
+using RateAndResolutionsBitmap = std::bitset<32>;
 
 // NOTE : Do not change the elements order in the following enums!
 
@@ -134,22 +138,22 @@ struct NativeVideoFormat {
 /**
  * A single video format that the source selects for streaming.
  *
- * SelectableH264VideoFormat is a H264 profile, H264 level, and a single CEA,
+ * H264VideoFormat is a H264 profile, H264 level, and a single CEA,
  * VESA or HH resolution. Sources are choosing the video format by matching what they
  * support to what the sink supports, and then they communicate the chosen format back
  * to the sink.
  */
-struct SelectableH264VideoFormat {
-  SelectableH264VideoFormat()
+struct H264VideoFormat {
+  H264VideoFormat()
   : profile(CBP), level(k3_1), type(CEA), rate_resolution(CEA640x480p60) {}
 
-  SelectableH264VideoFormat(H264Profile profile, H264Level level, CEARatesAndResolutions rr)
+  H264VideoFormat(H264Profile profile, H264Level level, CEARatesAndResolutions rr)
   : profile(profile), level(level), type(CEA), rate_resolution(rr) {}
 
-  SelectableH264VideoFormat(H264Profile profile, H264Level level, VESARatesAndResolutions rr)
+  H264VideoFormat(H264Profile profile, H264Level level, VESARatesAndResolutions rr)
   : profile(profile), level(level), type(VESA), rate_resolution(rr) {}
 
-  SelectableH264VideoFormat(H264Profile profile, H264Level level, HHRatesAndResolutions rr)
+  H264VideoFormat(H264Profile profile, H264Level level, HHRatesAndResolutions rr)
   : profile(profile), level(level), type(HH), rate_resolution(rr) {}
 
   H264Profile profile;
@@ -159,31 +163,54 @@ struct SelectableH264VideoFormat {
 };
 
 /**
- * A list of video formats supported by the sink.
+ * Represents <profile, level, misc-params, max-hres, max-vres> tuple used in 'wfd-video-formats'.
  *
- * SupportedH264VideoFormats is a H264 profile, H264 level, and three sets of
- * CEA, VESA and HH resolutions. Sinks send one or several SupportedH264VideoFormats
+ * H264VideoCodec is a H264 profile, H264 level, and three sets of
+ * CEA, VESA and HH resolutions. Sinks send one or several H264VideoCodec
  * to sources (for example because supported resolutions might
  * be different for CBP and CHP).
  */
-struct SupportedH264VideoFormats {
-  SupportedH264VideoFormats()
-  : profile(CBP), level(k3_1), cea_rr({CEA640x480p60}) {}
+struct H264VideoCodec {
+  H264VideoCodec()
+  : profile(CBP), level(k3_1), cea_rr(RateAndResolutionsBitmap().set(CEA640x480p60)) {}
 
-  SupportedH264VideoFormats(H264Profile profile, H264Level level,
-                  const std::vector<CEARatesAndResolutions>& cea,
-                  const std::vector<VESARatesAndResolutions>& vesa,
-                  const std::vector<HHRatesAndResolutions>& hh
-                 )
+  H264VideoCodec(H264Profile profile, H264Level level,
+                  const RateAndResolutionsBitmap& cea,
+                  const RateAndResolutionsBitmap& vesa,
+                  const RateAndResolutionsBitmap& hh)
   : profile(profile), level(level), cea_rr(cea), vesa_rr(vesa), hh_rr(hh) {}
 
   H264Profile profile;
   H264Level level;
-  std::vector<CEARatesAndResolutions> cea_rr;
-  std::vector<VESARatesAndResolutions> vesa_rr;
-  std::vector<HHRatesAndResolutions> hh_rr;
+  RateAndResolutionsBitmap cea_rr;
+  RateAndResolutionsBitmap vesa_rr;
+  RateAndResolutionsBitmap hh_rr;
 };
 
+/**
+ * An auxiliary function which populates list of @c H264VideoFormat
+ * items from the given @c H264VideoCodec instance.
+ *
+ * @param codec the given @c H264VideoCodec instance.
+ * @param formats resulting list of @c H264VideoFormat items
+ */
+WDS_EXPORT void PopulateVideoFormatList(
+    const H264VideoCodec& codec,
+    std::vector<H264VideoFormat>& formats);
+
+/**
+ * An auxiliary function to find the optimal format for streaming.
+ * The quality selection algorithm will pick codec with higher bandwidth.
+ *
+ * @param native format of a remote device
+ * @param local_codecs list of H264 codecs that are supported by local device
+ * @param remote_codecs list of H264 codecs that are supported by remote device
+ * @return optimal H264 video format
+ */
+WDS_EXPORT H264VideoFormat FindOptimalVideoFormat(
+    const NativeVideoFormat& remote_native_format,
+    const std::vector<H264VideoCodec>& local_codecs,
+    const std::vector<H264VideoCodec>& remote_codecs);
 
 }  // namespace wds
 

--- a/libwds/rtsp/CMakeLists.txt
+++ b/libwds/rtsp/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(wdsrtsp OBJECT
     preferreddisplaymode.cpp uibccapability.cpp propertyerrors.cpp scanner.cpp
 )
 
-add_executable(test-wds tests.cpp $<TARGET_OBJECTS:wdsrtsp>)
+add_executable(test-wds tests.cpp $<TARGET_OBJECTS:wdsrtsp> $<TARGET_OBJECTS:wdscommon>)
 set(LINK_FLAGS ${LINK_FLAGS} "-Wl,-whole-archive")
 target_link_libraries (test-wds)
 

--- a/libwds/rtsp/tests.cpp
+++ b/libwds/rtsp/tests.cpp
@@ -504,7 +504,7 @@ static bool test_valid_get_parameter_reply ()
   std::shared_ptr<wds::rtsp::VideoFormats> video_formats = std::static_pointer_cast<wds::rtsp::VideoFormats> (prop);
   ASSERT_EQUAL(video_formats->GetNativeFormat().rate_resolution, 8);
   ASSERT_EQUAL(video_formats->GetNativeFormat().type, 0);
-  ASSERT_EQUAL(video_formats->GetSelectableH264Formats().size(), 96);
+  ASSERT_EQUAL(video_formats->GetH264Formats().size(), 96);
 
   ASSERT_NO_EXCEPTION (prop =
       payload.get_property(wds::rtsp::PropertyType::WFD_3D_FORMATS));
@@ -701,7 +701,7 @@ static bool test_valid_set_parameter ()
   std::shared_ptr<wds::rtsp::VideoFormats> video_formats = std::static_pointer_cast<wds::rtsp::VideoFormats> (prop);
   ASSERT_EQUAL(video_formats->GetNativeFormat().rate_resolution, 11);
   ASSERT_EQUAL(video_formats->GetNativeFormat().type, 2);
-  ASSERT_EQUAL(video_formats->GetSelectableH264Formats().size(), 1);
+  ASSERT_EQUAL(video_formats->GetH264Formats().size(), 1);
 
   ASSERT_NO_EXCEPTION (prop =
       payload.get_property(wds::rtsp::PropertyType::WFD_CLIENT_RTP_PORTS));

--- a/libwds/rtsp/videoformats.cpp
+++ b/libwds/rtsp/videoformats.cpp
@@ -41,8 +41,8 @@ unsigned int EnumListToMask(const std::vector<EnumType>& from) {
 }
 } //namespace
 
-using wds::SelectableH264VideoFormat;
-using wds::SupportedH264VideoFormats;
+using wds::H264VideoFormat;
+using wds::H264VideoCodec;
 
 H264Codec::H264Codec(unsigned char profile, unsigned char level,
     unsigned int cea_support, unsigned int vesa_support,
@@ -50,82 +50,82 @@ H264Codec::H264Codec(unsigned char profile, unsigned char level,
     unsigned short min_slice_size, unsigned short slice_enc_params,
     unsigned char frame_rate_control_support,
     unsigned short max_hres, unsigned short max_vres)
-  : profile_(profile),
-    level_(level),
-    cea_support_(cea_support),
-    vesa_support_(vesa_support),
-    hh_support_(hh_support),
-    latency_(latency),
-    min_slice_size_(min_slice_size),
-    slice_enc_params_(slice_enc_params),
-    frame_rate_control_support_(frame_rate_control_support),
-    max_hres_(max_hres),
-    max_vres_(max_vres) {}
+  : profile(profile),
+    level(level),
+    cea_support(cea_support),
+    vesa_support(vesa_support),
+    hh_support(hh_support),
+    latency(latency),
+    min_slice_size(min_slice_size),
+    slice_enc_params(slice_enc_params),
+    frame_rate_control_support(frame_rate_control_support),
+    max_hres(max_hres),
+    max_vres(max_vres) {}
 
-H264Codec::H264Codec(SelectableH264VideoFormat format)
-  : profile_(1 << format.profile),
-    level_(1 << format.level),
-    cea_support_((format.type == CEA) ? 1 << format.rate_resolution : 0),
-    vesa_support_((format.type == VESA) ? 1 << format.rate_resolution : 0),
-    hh_support_((format.type == HH) ? 1 << format.rate_resolution : 0),
-    latency_(0),
-    min_slice_size_(0),
-    slice_enc_params_(0),
-    frame_rate_control_support_(0),
-    max_hres_(0),
-    max_vres_(0) {
+H264Codec::H264Codec(const H264VideoFormat& format)
+  : profile(1 << format.profile),
+    level(1 << format.level),
+    cea_support((format.type == CEA) ? 1 << format.rate_resolution : 0),
+    vesa_support((format.type == VESA) ? 1 << format.rate_resolution : 0),
+    hh_support((format.type == HH) ? 1 << format.rate_resolution : 0),
+    latency(0),
+    min_slice_size(0),
+    slice_enc_params(0),
+    frame_rate_control_support(0),
+    max_hres(0),
+    max_vres(0) {
 
 }
 
-H264Codec::H264Codec(SupportedH264VideoFormats format)
-  : profile_(1 << format.profile),
-    level_(1 << format.level),
-    cea_support_(EnumListToMask(format.cea_rr)),
-    vesa_support_(EnumListToMask(format.vesa_rr)),
-    hh_support_(EnumListToMask(format.hh_rr)),
-    latency_(0),
-    min_slice_size_(0),
-    slice_enc_params_(0),
-    frame_rate_control_support_(0),
-    max_hres_(0),
-    max_vres_(0) {
+H264Codec::H264Codec(const H264VideoCodec& format)
+  : profile(1 << format.profile),
+    level(1 << format.level),
+    cea_support(format.cea_rr.to_ulong()),
+    vesa_support(format.vesa_rr.to_ulong()),
+    hh_support(format.hh_rr.to_ulong()),
+    latency(0),
+    min_slice_size(0),
+    slice_enc_params(0),
+    frame_rate_control_support(0),
+    max_hres(0),
+    max_vres(0) {
 
 }
 
 
 std::string H264Codec::ToString() const {
   std::string ret;
-  MAKE_HEX_STRING_2(profile, profile_);
-  MAKE_HEX_STRING_2(level, level_);
-  MAKE_HEX_STRING_8(cea_support, cea_support_);
-  MAKE_HEX_STRING_8(vesa_support, vesa_support_);
-  MAKE_HEX_STRING_8(hh_support, hh_support_);
-  MAKE_HEX_STRING_2(latency,latency_);
-  MAKE_HEX_STRING_4(min_slice_size, min_slice_size_);
-  MAKE_HEX_STRING_4(slice_enc_params, slice_enc_params_);
-  MAKE_HEX_STRING_2(frame_rate_control_support, frame_rate_control_support_);
+  MAKE_HEX_STRING_2(profile_str, profile);
+  MAKE_HEX_STRING_2(level_str, level);
+  MAKE_HEX_STRING_8(cea_support_str, cea_support);
+  MAKE_HEX_STRING_8(vesa_support_str, vesa_support);
+  MAKE_HEX_STRING_8(hh_support_str, hh_support);
+  MAKE_HEX_STRING_2(latency_str, latency);
+  MAKE_HEX_STRING_4(min_slice_size_str, min_slice_size);
+  MAKE_HEX_STRING_4(slice_enc_params_str, slice_enc_params);
+  MAKE_HEX_STRING_2(frame_rate_control_support_str, frame_rate_control_support);
 
-  ret = profile + std::string(SPACE)
-      + level + std::string(SPACE)
-      + cea_support + std::string(SPACE)
-      + vesa_support + std::string(SPACE)
-      + hh_support + std::string(SPACE)
-      + latency + std::string(SPACE)
-      + min_slice_size + std::string(SPACE)
-      + slice_enc_params + std::string(SPACE)
-      + frame_rate_control_support + std::string(SPACE);
+  ret = profile_str + std::string(SPACE)
+      + level_str + std::string(SPACE)
+      + cea_support_str + std::string(SPACE)
+      + vesa_support_str + std::string(SPACE)
+      + hh_support_str + std::string(SPACE)
+      + latency_str + std::string(SPACE)
+      + min_slice_size_str + std::string(SPACE)
+      + slice_enc_params_str + std::string(SPACE)
+      + frame_rate_control_support_str + std::string(SPACE);
 
-  if (max_hres_ > 0) {
-    MAKE_HEX_STRING_4(max_hres, max_hres_);
-    ret += max_hres;
+  if (max_hres > 0) {
+    MAKE_HEX_STRING_4(max_hres_str, max_hres);
+    ret += max_hres_str;
   } else {
     ret += NONE;
   }
   ret += std::string(SPACE);
 
-  if (max_vres_ > 0) {
-    MAKE_HEX_STRING_4(max_vres, max_vres_);
-    ret += max_vres;
+  if (max_vres > 0) {
+    MAKE_HEX_STRING_4(max_vres_str, max_vres);
+    ret += max_vres_str;
   } else {
     ret += NONE;
   }
@@ -182,27 +182,14 @@ inline H264Level ToH264Level(unsigned char level) {
 
 }  // namespace
 
-void H264Codec::ToSelectableVideoFormats(std::vector<SelectableH264VideoFormat>& formats) const {
-  auto profile = ToH264Profile(profile_);
-  auto level = ToH264Level(level_);
-  if (cea_support_ != 0) {
-    auto list = MaskToEnumList<wds::CEARatesAndResolutions>(
-        cea_support_, CEA1920x1080p24);
-    for(auto rate_resolution: list)
-      formats.push_back(SelectableH264VideoFormat(profile, level, rate_resolution));
-  }
-  if (vesa_support_ != 0) {
-    auto list = MaskToEnumList<wds::VESARatesAndResolutions>(
-        vesa_support_, VESA1920x1200p30);
-    for(auto rate_resolution: list)
-      formats.push_back(SelectableH264VideoFormat(profile, level, rate_resolution));
-  }
-  if (hh_support_ != 0) {
-    auto list = MaskToEnumList<wds::HHRatesAndResolutions>(
-        hh_support_, HH848x480p60);
-    for(auto rate_resolution: list)
-      formats.push_back(SelectableH264VideoFormat(profile, level, rate_resolution));
-  }
+H264VideoCodec H264Codec::ToH264VideoCodec() const {
+  H264VideoCodec result;
+  result.profile = ToH264Profile(profile);
+  result.level = ToH264Level(level);
+  result.cea_rr = RateAndResolutionsBitmap(cea_support);
+  result.vesa_rr = RateAndResolutionsBitmap(vesa_support);
+  result.hh_rr = RateAndResolutionsBitmap(hh_support);
+  return result;
 }
 
 VideoFormats::VideoFormats() : Property(WFD_VIDEO_FORMATS, true) {
@@ -210,7 +197,7 @@ VideoFormats::VideoFormats() : Property(WFD_VIDEO_FORMATS, true) {
 
 VideoFormats::VideoFormats(NativeVideoFormat format,
     bool preferred_display_mode,
-    const std::vector<SelectableH264VideoFormat>& h264_formats)
+    const std::vector<H264VideoFormat>& h264_formats)
   : Property(WFD_VIDEO_FORMATS),
     preferred_display_mode_(preferred_display_mode ? 1 : 0) {
   native_ = (format.rate_resolution << 3) | format.type;
@@ -220,7 +207,7 @@ VideoFormats::VideoFormats(NativeVideoFormat format,
 
 VideoFormats::VideoFormats(NativeVideoFormat format,
     bool preferred_display_mode,
-    const std::vector<SupportedH264VideoFormats>& h264_formats)
+    const std::vector<H264VideoCodec>& h264_formats)
   : Property(WFD_VIDEO_FORMATS),
     preferred_display_mode_(preferred_display_mode ? 1 : 0) {
   native_ = (format.rate_resolution << 3) | format.type;
@@ -257,11 +244,11 @@ NativeVideoFormat VideoFormats::GetNativeFormat() const {
   unsigned selection_bits = native_ & 7;
   switch (selection_bits) {
   case 0: // 0b000 CEA
-    return GetFormatFromIndex<wds::CEARatesAndResolutions>(index, CEA1920x1080p24);
+    return GetFormatFromIndex<CEARatesAndResolutions>(index, CEA1920x1080p24);
   case 1: // 0b001 VESA
-    return GetFormatFromIndex<wds::VESARatesAndResolutions>(index, VESA1920x1200p30);
+    return GetFormatFromIndex<VESARatesAndResolutions>(index, VESA1920x1200p30);
   case 2: // 0b010 HH
-    return GetFormatFromIndex<wds::HHRatesAndResolutions>(index, HH848x480p60);
+    return GetFormatFromIndex<HHRatesAndResolutions>(index, HH848x480p60);
   default:
     assert(false);
     break;
@@ -269,10 +256,17 @@ NativeVideoFormat VideoFormats::GetNativeFormat() const {
   return NativeVideoFormat(CEA640x480p60);
 }
 
-std::vector<SelectableH264VideoFormat> VideoFormats::GetSelectableH264Formats() const {
-  std::vector<SelectableH264VideoFormat> result;
+std::vector<H264VideoFormat> VideoFormats::GetH264Formats() const {
+  std::vector<H264VideoFormat> result;
   for (const auto& codec : h264_codecs_)
-    codec.ToSelectableVideoFormats(result);
+    PopulateVideoFormatList(codec.ToH264VideoCodec(), result);
+  return result;
+}
+
+std::vector<H264VideoCodec> VideoFormats::GetH264VideoCodecs() const {
+  std::vector<H264VideoCodec> result;
+  for (const auto& codec : h264_codecs_)
+    result.push_back(codec.ToH264VideoCodec());
   return result;
 }
 

--- a/libwds/rtsp/videoformats.h
+++ b/libwds/rtsp/videoformats.h
@@ -40,26 +40,24 @@ struct H264Codec {
       unsigned char frame_rate_control_support,
       unsigned short max_hres, unsigned short max_vres);
 
-  H264Codec(SelectableH264VideoFormat format);
+  H264Codec(const H264VideoFormat& format);
+  H264Codec(const H264VideoCodec& format);
 
-  H264Codec(SupportedH264VideoFormats format);
-
-  void ToSelectableVideoFormats(std::vector<SelectableH264VideoFormat>& formats) const;
+  H264VideoCodec ToH264VideoCodec() const;
 
   std::string ToString() const;
 
- private:
-  unsigned char profile_;
-  unsigned char level_;
-  unsigned int cea_support_;
-  unsigned int vesa_support_;
-  unsigned int hh_support_;
-  unsigned char latency_;
-  unsigned short min_slice_size_;
-  unsigned short slice_enc_params_;
-  unsigned char frame_rate_control_support_;
-  unsigned short max_hres_;
-  unsigned short max_vres_;
+  unsigned char profile;
+  unsigned char level;
+  unsigned int cea_support;
+  unsigned int vesa_support;
+  unsigned int hh_support;
+  unsigned char latency;
+  unsigned short min_slice_size;
+  unsigned short slice_enc_params;
+  unsigned char frame_rate_control_support;
+  unsigned short max_hres;
+  unsigned short max_vres;
 };
 
 using H264Codecs = std::vector<H264Codec>;
@@ -67,19 +65,21 @@ using H264Codecs = std::vector<H264Codec>;
 class VideoFormats: public Property {
  public:
   VideoFormats();
-  VideoFormats(wds::NativeVideoFormat format,
+  VideoFormats(NativeVideoFormat format,
                bool preferred_display_mode,
-               const std::vector<wds::SelectableH264VideoFormat>& h264_formats);
-  VideoFormats(wds::NativeVideoFormat format,
+               const std::vector<H264VideoFormat>& h264_formats);
+  VideoFormats(NativeVideoFormat format,
                bool preferred_display_mode,
-               const std::vector<wds::SupportedH264VideoFormats>& h264_formats);
+               const std::vector<H264VideoCodec>& h264_formats);
   VideoFormats(unsigned char native,
                unsigned char preferred_display_mode,
                const H264Codecs& h264_codecs);
   ~VideoFormats() override;
 
   NativeVideoFormat GetNativeFormat() const;
-  std::vector<SelectableH264VideoFormat> GetSelectableH264Formats() const;
+
+  std::vector<H264VideoFormat> GetH264Formats() const;
+  std::vector<H264VideoCodec> GetH264VideoCodecs() const;
 
   std::string ToString() const override;
 

--- a/libwds/source/cap_negotiation_state.cpp
+++ b/libwds/source/cap_negotiation_state.cpp
@@ -92,27 +92,25 @@ bool M3Handler::HandleReply(Reply* reply) {
 
   auto video_formats = static_cast<VideoFormats*>(
       reply->payload().get_property(rtsp::WFD_VIDEO_FORMATS).get());
+
+  auto audio_codecs = static_cast<AudioCodecs*>(
+      reply->payload().get_property(rtsp::WFD_AUDIO_CODECS).get());
+
   if (!video_formats) {
     WDS_ERROR("Failed to obtain WFD_VIDEO_FORMATS property");
     return false;
   }
 
-  auto audio_codecs = static_cast<AudioCodecs*>(
-      reply->payload().get_property(rtsp::WFD_AUDIO_CODECS).get());
-  if (!audio_codecs) {
-    WDS_ERROR("Failed to obtain WFD_AUDIO_CODECS property");
-    return false;
-  }
-
   if (!source_manager->InitOptimalVideoFormat(
       video_formats->GetNativeFormat(),
-      video_formats->GetSelectableH264Formats())) {
-    WDS_ERROR("Failed to initalize optimal video format.");
+      video_formats->GetH264VideoCodecs())) {
+    WDS_ERROR("Cannot initalize optimal video format from the supported by sink.");
     return false;
   }
 
-  if (!source_manager->InitOptimalAudioFormat(audio_codecs->audio_codecs())) {
-    WDS_ERROR("Failed to initalize optimal audio format.");
+  if (audio_codecs && !source_manager->InitOptimalAudioFormat(
+      audio_codecs->audio_codecs())) {
+    WDS_ERROR("Cannot initalize optimal audio format from the supported by sink.");
     return false;
   }
 

--- a/sink/gst_sink_media_manager.cpp
+++ b/sink/gst_sink_media_manager.cpp
@@ -61,32 +61,30 @@ std::string GstSinkMediaManager::GetSessionId() const {
   return session_;
 }
 
-std::vector<wds::SupportedH264VideoFormats>
-GstSinkMediaManager::GetSupportedH264VideoFormats() const {
+std::vector<wds::H264VideoCodec>
+GstSinkMediaManager::GetSupportedH264VideoCodecs() const {
+  wds::RateAndResolutionsBitmap cea_rr;
+  wds::RateAndResolutionsBitmap vesa_rr;
+  wds::RateAndResolutionsBitmap hh_rr;
+  wds::RateAndResolution i;
   // declare that we support all resolutions, CHP and level 4.2
   // gstreamer should handle all of it :)
-  std::vector<wds::CEARatesAndResolutions> cea_rr;
-  std::vector<wds::VESARatesAndResolutions> vesa_rr;
-  std::vector<wds::HHRatesAndResolutions> hh_rr;
-  wds::RateAndResolution i;
-
-  for (i = wds::CEA640x480p60; i <= wds::CEA1920x1080p24; i++)
-      cea_rr.push_back(static_cast<wds::CEARatesAndResolutions>(i));
-  for (i = wds::VESA800x600p30; i <= wds::VESA1920x1200p30; i++)
-      vesa_rr.push_back(static_cast<wds::VESARatesAndResolutions>(i));
-  for (i = wds::HH800x480p30; i <= wds::HH848x480p60; i++)
-      hh_rr.push_back(static_cast<wds::HHRatesAndResolutions>(i));
-  return {wds::SupportedH264VideoFormats(wds::CHP, wds::k4_2, cea_rr, vesa_rr, hh_rr),
-          wds::SupportedH264VideoFormats(wds::CBP, wds::k4_2, cea_rr, vesa_rr, hh_rr)};
+  for (i = wds::CEA640x480p60; i <= wds::CEA1920x1080p24; ++i)
+    cea_rr.set(i);
+  for (i = wds::VESA800x600p30; i <= wds::VESA1920x1200p30; ++i)
+    vesa_rr.set(i);
+  for (i = wds::HH800x480p30; i <= wds::HH848x480p60; ++i)
+    hh_rr.set(i);
+  return {wds::H264VideoCodec(wds::CHP, wds::k4_2, cea_rr, vesa_rr, hh_rr),
+          wds::H264VideoCodec(wds::CBP, wds::k4_2, cea_rr, vesa_rr, hh_rr)};
 }
 
-wds::NativeVideoFormat GstSinkMediaManager::GetSupportedNativeVideoFormat() const {
+wds::NativeVideoFormat GstSinkMediaManager::GetNativeVideoFormat() const {
   // pick the maximum possible resolution, let gstreamer deal with it
   // TODO: get the actual screen size of the system
   return wds::NativeVideoFormat(wds::CEA1920x1080p60);
 }
 
-bool GstSinkMediaManager::SetOptimalVideoFormat(
-    const wds::SelectableH264VideoFormat& optimal_format) {
+bool GstSinkMediaManager::SetOptimalVideoFormat(const wds::H264VideoFormat& optimal_format) {
   return true;
 }

--- a/sink/gst_sink_media_manager.h
+++ b/sink/gst_sink_media_manager.h
@@ -41,9 +41,9 @@ class GstSinkMediaManager : public wds::SinkMediaManager {
   void SetSessionId(const std::string& session) override;
   std::string GetSessionId() const override;
 
-  std::vector<wds::SupportedH264VideoFormats> GetSupportedH264VideoFormats() const override;
-  wds::NativeVideoFormat GetSupportedNativeVideoFormat() const override;
-  bool SetOptimalVideoFormat(const wds::SelectableH264VideoFormat& optimal_format) override;
+  std::vector<wds::H264VideoCodec> GetSupportedH264VideoCodecs() const override;
+  wds::NativeVideoFormat GetNativeVideoFormat() const override;
+  bool SetOptimalVideoFormat(const wds::H264VideoFormat& optimal_format) override;
 
  private:
   std::string hostname_;


### PR DESCRIPTION
- Renaming to better reflect the Miracast specification
- Use std::bitset in H264 video codec structures for simplicity
- Removed the unneeded methods from MediaManager interface
- Moved video format aux function to video_format.cpp file
- Fixes in M3, M4 messages handling