### PR TITLE
Fix build dependencies

### DIFF
--- a/libwds/common/CMakeLists.txt
+++ b/libwds/common/CMakeLists.txt
@@ -5,3 +5,4 @@ include_directories ("${PROJECT_SOURCE_DIR}" )
 
 add_library(wdscommon OBJECT
     message_handler.cpp rtsp_input_handler.cpp video_format.cpp)
+add_dependencies(wdscommon wdsrtsp)

--- a/libwds/sink/CMakeLists.txt
+++ b/libwds/sink/CMakeLists.txt
@@ -7,3 +7,4 @@ add_library(wdssink OBJECT
     sink.cpp cap_negotiation_state.cpp init_state.cpp
     session_state.cpp streaming_state.cpp
 )
+add_dependencies(wdssink wdsrtsp)

--- a/libwds/source/CMakeLists.txt
+++ b/libwds/source/CMakeLists.txt
@@ -6,3 +6,4 @@ include_directories ("${PROJECT_SOURCE_DIR}" )
 add_library(wdssource OBJECT
     source.cpp cap_negotiation_state.cpp init_state.cpp
     session_state.cpp streaming_state.cpp)
+add_dependencies(wdssource wdsrtsp)


### PR DESCRIPTION
This makes sure wdsrtsp is built before any other libwds components,
so that parser's generated files are guaranteed to exist. Also parallel
builds should work now.