### PR TITLE
initial support for windows tablets

### DIFF
--- a/libwds/sink/cap_negotiation_state.cpp
+++ b/libwds/sink/cap_negotiation_state.cpp
@@ -123,11 +123,13 @@ M4Handler::M4Handler(const InitParams& init_params)
 }
 
 std::unique_ptr<Reply> M4Handler::HandleMessage(Message* message) {
+  SinkMediaManager* sink_media_manager = ToSinkMediaManager(manager_);
+
   auto presentation_url =
       static_cast<rtsp::PresentationUrl*>(message->payload().get_property(rtsp::WFD_PRESENTATION_URL).get());
-  assert(presentation_url);
-  SinkMediaManager* sink_media_manager = ToSinkMediaManager(manager_);
-  sink_media_manager->SetPresentationUrl(presentation_url->presentation_url_1());
+  if (presentation_url) {
+    sink_media_manager->SetPresentationUrl(presentation_url->presentation_url_1());
+  }
 
   auto video_formats =
       static_cast<rtsp::VideoFormats*>(message->payload().get_property(rtsp::WFD_VIDEO_FORMATS).get());

--- a/libwds/sink/cap_negotiation_state.cpp
+++ b/libwds/sink/cap_negotiation_state.cpp
@@ -109,8 +109,7 @@ std::unique_ptr<Reply> M3Handler::HandleMessage(Message* message) {
           new_prop.reset(new StandbyResumeCapability(false));
           reply->payload().add_property(new_prop);
       } else {
-          WDS_ERROR("** GET_PARAMETER: Property not supported");
-          return std::unique_ptr<Reply>(new Reply(STATUS_NotImplemented));
+          WDS_WARNING("** GET_PARAMETER: Ignoring unsupported property '%s'.", (*it).c_str());
       }
   }
 

--- a/libwds/sink/sink.cpp
+++ b/libwds/sink/sink.cpp
@@ -57,6 +57,8 @@ bool InitializeRequestId(Request* request) {
   case Request::MethodSetParameter:
     if (request->payload().has_property(rtsp::WFD_PRESENTATION_URL))
       id = Request::M4;
+    else if (request->payload().has_property(rtsp::WFD_AV_FORMAT_CHANGE_TIMING))
+      id = Request::M4;
     else if (request->payload().has_property(rtsp::WFD_TRIGGER_METHOD))
       id = Request::M5;
     break;


### PR DESCRIPTION
With these changes (and the device type issue mentioned in the wiki) I can display the screen of the two windows tablets I have here.
It currently only works for the first connection but not for known devices, but that's a wpa_supplicant / connman problem.