### PR TITLE
SinkMediaManager API to provide connector type

### DIFF
--- a/libwds/public/connector_type.h
+++ b/libwds/public/connector_type.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of Wireless Display Software for Linux OS
  *
- * Copyright (C) 2014 Intel Corporation.
+ * Copyright (C) 2015 Intel Corporation.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,30 +19,18 @@
  * 02110-1301 USA
  */
 
-
-#ifndef CONNECTORTYPE_H_
-#define CONNECTORTYPE_H_
-
-#include "property.h"
-#include "libwds/public/connector_type.h"
+#ifndef CONNECTOR_TYPE_H_
+#define CONNECTOR_TYPE_H_
 
 namespace wds {
-namespace rtsp {
 
-class ConnectorType: public Property {
- public:
-  ConnectorType();
-  explicit ConnectorType(unsigned char connector_type);
-  explicit ConnectorType(wds::ConnectorType connector_type);
-  ~ConnectorType() override;
-
-  unsigned char connector_type() const { return connector_type_; }
-  std::string ToString() const override;
-
- private:
-  unsigned char connector_type_;
+enum ConnectorType {
+  ConnectorTypeVGA = 0,
+  // TODO : Add the rest of connector types.
+  ConnectorTypeUndefined = 255,
+  ConnectorTypeNone
 };
 
-}  // namespace rtsp
 }  // namespace wds
-#endif  // CONNECTORTYPE_H_
+
+#endif  // CONNECTOR_TYPE_H_

--- a/libwds/public/media_manager.h
+++ b/libwds/public/media_manager.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 #include "audio_codec.h"
+#include "connector_type.h"
 #include "video_format.h"
 #include "wds_export.h"
 
@@ -139,6 +140,12 @@ class SinkMediaManager : public MediaManager {
    * @return true if format can be used by media manager, false otherwise
    */
   virtual bool SetOptimalVideoFormat(const H264VideoFormat& optimal_format) = 0;
+
+  /**
+   * Returns active connector type of a device
+   * @return connector type. @see ConnectorType
+   */
+  virtual ConnectorType GetConnectorType() const = 0;
 };
 
 /**

--- a/libwds/rtsp/connectortype.cpp
+++ b/libwds/rtsp/connectortype.cpp
@@ -28,12 +28,19 @@ namespace wds {
 namespace rtsp {
 
 ConnectorType::ConnectorType()
-  : Property(WFD_CONNECTOR_TYPE, true) {
+  : Property(WFD_CONNECTOR_TYPE, true),
+    connector_type_() {
 }
 
-ConnectorType::ConnectorType(unsigned short connector_type)
+ConnectorType::ConnectorType(unsigned char connector_type)
   : Property(WFD_CONNECTOR_TYPE),
     connector_type_(connector_type) {
+}
+
+ConnectorType::ConnectorType(wds::ConnectorType connector_type)
+  : Property(WFD_CONNECTOR_TYPE, connector_type == wds::ConnectorTypeNone) {
+  connector_type_ = is_none() ? 0  // Ignored.
+                              : static_cast<unsigned char>(connector_type);
 }
 
 ConnectorType::~ConnectorType() {

--- a/libwds/sink/cap_negotiation_state.cpp
+++ b/libwds/sink/cap_negotiation_state.cpp
@@ -56,6 +56,7 @@ M3Handler::M3Handler(const InitParams& init_params)
 }
 
 std::unique_ptr<Reply> M3Handler::HandleMessage(Message* message) {
+  // FIXME : resolve clashes between wds exported and internal rtsp type names.
   using namespace rtsp;
 
   auto reply = std::unique_ptr<Reply>(new Reply(rtsp::STATUS_OK));
@@ -102,7 +103,7 @@ std::unique_ptr<Reply> M3Handler::HandleMessage(Message* message) {
           new_prop.reset(new UIBCCapability());
           reply->payload().add_property(new_prop);
       } else if (*it == PropertyName::name[PropertyType::WFD_CONNECTOR_TYPE]){
-          new_prop.reset(new ConnectorType());
+          new_prop.reset(new rtsp::ConnectorType(ToSinkMediaManager(manager_)->GetConnectorType()));
           reply->payload().add_property(new_prop);
       } else if (*it == PropertyName::name[PropertyType::WFD_STANDBY_RESUME_CAPABILITY]){
           new_prop.reset(new StandbyResumeCapability(false));

--- a/sink/gst_sink_media_manager.cpp
+++ b/sink/gst_sink_media_manager.cpp
@@ -88,3 +88,7 @@ wds::NativeVideoFormat GstSinkMediaManager::GetNativeVideoFormat() const {
 bool GstSinkMediaManager::SetOptimalVideoFormat(const wds::H264VideoFormat& optimal_format) {
   return true;
 }
+
+wds::ConnectorType GstSinkMediaManager::GetConnectorType() const {
+  return wds::ConnectorTypeNone;
+}

--- a/sink/gst_sink_media_manager.h
+++ b/sink/gst_sink_media_manager.h
@@ -44,6 +44,7 @@ class GstSinkMediaManager : public wds::SinkMediaManager {
   std::vector<wds::H264VideoCodec> GetSupportedH264VideoCodecs() const override;
   wds::NativeVideoFormat GetNativeVideoFormat() const override;
   bool SetOptimalVideoFormat(const wds::H264VideoFormat& optimal_format) override;
+  wds::ConnectorType GetConnectorType() const override;
 
  private:
   std::string hostname_;


### PR DESCRIPTION
Before the change the device connector type value was hardcoded to 'none'. This patch allowes clients to provide the actual connector type value.