### PR TITLE
network: cancel timeouts when releasing the timer

### DIFF
--- a/mirac_network/mirac-broker.hpp
+++ b/mirac_network/mirac-broker.hpp
@@ -64,6 +64,7 @@ class MiracBroker : public wds::Peer::Delegate
         static gboolean listen_cb (gint fd, GIOCondition condition, gpointer data_ptr);
         static gboolean connect_cb (gint fd, GIOCondition condition, gpointer data_ptr);
         static gboolean try_connect(gpointer data_ptr);
+        static void on_timeout_remove(gpointer user_data);
 
         gboolean send_cb (gint fd, GIOCondition condition);
         gboolean receive_cb (gint fd, GIOCondition condition);


### PR DESCRIPTION
Otherwise these timers will never be canceled and may be executed after the
object ist deleted.
Also drop the check in OnTimeout(). The timeout is canceled, so OnTimeout()
is never called for a released timer.

This is a followup patch for 85d82e90857d509c7da2ec7fa95feae233848479 which
did not fix all possible race conditions.