### PR TITLE
call getnameinfo() with NI_NUMERICHOST

### DIFF
--- a/mirac_network/mirac-network.cpp
+++ b/mirac_network/mirac-network.cpp
@@ -208,7 +208,7 @@ std::string MiracNetwork::GetPeerAddress ()
         reinterpret_cast<struct sockaddr *> (addrbuf.get()), addrsize,
         namebuf.get(), MIRAC_MAX_NAMELEN,
         servbuf.get(), MIRAC_MAX_NAMELEN,
-        NI_NOFQDN|NI_NUMERICSERV);
+        NI_NOFQDN|NI_NUMERICHOST|NI_NUMERICSERV);
     if (ec)
         throw MiracException(gai_strerror(ec), __FUNCTION__);
     return std::string(namebuf.get());


### PR DESCRIPTION
Otherwise it occasionally fails with EAI_AGAIN. Also, getnameinfo() is
called for the dynamically assigned IP address of the peer, so it is
unlikely that there is a hostname for it. Trying to look it up just slows
things down.