### PR TITLE
Introduce Peer::Observer interface

### DIFF
--- a/libwds/common/rtsp_input_handler.h
+++ b/libwds/common/rtsp_input_handler.h
@@ -27,21 +27,24 @@
 
 namespace wds {
 
-// An aux class to handle input buffer.
+// An aux class used to obtain Message object from the given raw input.
 class RTSPInputHandler {
  protected:
   RTSPInputHandler() = default;
   virtual ~RTSPInputHandler();
 
-  void InputReceived(const std::string& input);
+  void AddInput(const std::string& input);
+
+  // To be overridden.
   virtual void MessageParsed(std::unique_ptr<rtsp::Message> message) = 0;
+  virtual void ParserErrorOccurred(const std::string& invalid_input) {}
 
  private:
   bool ParseHeader();
   bool ParsePayload();
 
   rtsp::Driver driver_;
-  std::string rtsp_recieve_buffer_;
+  std::string rtsp_input_buffer_;
   std::unique_ptr<rtsp::Message> message_;
 };
 

--- a/libwds/public/source.h
+++ b/libwds/public/source.h
@@ -37,9 +37,12 @@ class Source : public Peer {
    * Factory method that creates Source state machine.
    * @param delegate that is used for networking
    * @param media manger that is used for media stream management
+   * @param observer
    * @return newly created Source instance
    */
-  static Source* Create(Peer::Delegate* delegate, SourceMediaManager* mng);
+  static Source* Create(Peer::Delegate* delegate,
+                        SourceMediaManager* mng,
+                        Peer::Observer* observer = nullptr);
 };
 
 }

--- a/libwds/sink/sink.cpp
+++ b/libwds/sink/sink.cpp
@@ -141,7 +141,7 @@ void SinkImpl::Reset() {
 }
 
 void SinkImpl::RTSPDataReceived(const std::string& message) {
-  InputReceived(message);
+  AddInput(message);
 }
 
 template <class WfdMessage, Request::ID id>

--- a/libwds/source/session_state.cpp
+++ b/libwds/source/session_state.cpp
@@ -94,20 +94,10 @@ M7Handler::M7Handler(const InitParams& init_params)
 std::unique_ptr<Reply> M7Handler::HandleMessage(
     Message* message) {
   if (!manager_->IsPaused())
-    return nullptr; // FIXME : Shouldn't we just send error code?
+    return std::unique_ptr<Reply>(new Reply(rtsp::STATUS_NotAcceptable));
   manager_->Play();
   return std::unique_ptr<Reply>(new Reply(rtsp::STATUS_OK));
 }
-
-M8Handler::M8Handler(const InitParams& init_params)
-  : MessageReceiver<Request::M8>(init_params) {
-}
-
-std::unique_ptr<Reply> M8Handler::HandleMessage(Message* message) {
-  manager_->Teardown(); // FIXME : make proper reset.
-  return std::unique_ptr<Reply>(new Reply(rtsp::STATUS_OK));
-}
-
 
 M16Sender::M16Sender(const InitParams& init_params)
   : OptionalMessageSender<Request::M16>(init_params) {
@@ -124,7 +114,6 @@ SessionState::SessionState(const InitParams& init_params, uint& timer_id,
   AddSequencedHandler(make_ptr(new M6Handler(init_params, timer_id)));
   AddSequencedHandler(make_ptr(new M7Handler(init_params)));
 
-  AddOptionalHandler(make_ptr(new M8Handler(init_params)));
   AddOptionalHandler(m16_sender);
 }
 

--- a/libwds/source/session_state.h
+++ b/libwds/source/session_state.h
@@ -36,15 +36,6 @@ class SessionState : public MessageSequenceWithOptionalSetHandler {
   ~SessionState() override;
 };
 
-class M8Handler final : public MessageReceiver<rtsp::Request::M8> {
- public:
-  M8Handler(const InitParams& init_params);
-
- private:
-  std::unique_ptr<rtsp::Reply> HandleMessage(
-      rtsp::Message* message) override;
-};
-
 class M7Handler final : public MessageReceiver<rtsp::Request::M7> {
  public:
   M7Handler(const InitParams& init_params);

--- a/libwds/source/streaming_state.cpp
+++ b/libwds/source/streaming_state.cpp
@@ -34,6 +34,20 @@ using rtsp::Reply;
 
 namespace source {
 
+class M8Handler final : public MessageReceiver<rtsp::Request::M8> {
+ public:
+  M8Handler(const InitParams& init_params)
+    : MessageReceiver<Request::M8>(init_params) {
+  }
+
+ private:
+  std::unique_ptr<rtsp::Reply> HandleMessage(
+      rtsp::Message* message) override {
+    manager_->Teardown();
+    return std::unique_ptr<Reply>(new Reply(rtsp::STATUS_OK));
+  }
+};
+
 class M9Handler final : public MessageReceiver<Request::M9> {
  public:
   M9Handler(const InitParams& init_params)


### PR DESCRIPTION
The Peer::Observer interface can be used by the libwds client in order
to get notifications from the state machine about session completion or
occurred errors.

At the moment the Peer::Observer interface is actually  supported only
for the Wi-Fi Display source clients.