### PR TITLE
Conditional AV format send

### DIFF
--- a/libwds/common/video_format.cpp
+++ b/libwds/common/video_format.cpp
@@ -118,20 +118,17 @@ static QualityInfo hh_info_table[] = {
 #define HH_TABLE_LENGTH  sizeof(hh_info_table) / sizeof(QualityInfo)
 
 QualityInfo get_cea_info(const H264VideoFormat& format) {
-  if (format.rate_resolution > CEA_TABLE_LENGTH)
-    assert(false);
+  assert(format.rate_resolution < CEA_TABLE_LENGTH);
   return cea_info_table[format.rate_resolution];
 }
 
 QualityInfo get_vesa_info(const H264VideoFormat& format) {
-  if (format.rate_resolution > VESA_TABLE_LENGTH)
-    assert(false);
+  assert(format.rate_resolution < VESA_TABLE_LENGTH);
   return vesa_info_table[format.rate_resolution];
 }
 
 QualityInfo get_hh_info(const H264VideoFormat& format) {
-  if (format.rate_resolution > HH_TABLE_LENGTH)
-    assert(false);
+  assert(format.rate_resolution < HH_TABLE_LENGTH);
   return hh_info_table[format.rate_resolution];
 }
 
@@ -221,8 +218,7 @@ H264VideoFormat FindOptimalVideoFormat(
   auto it = local_formats.begin();
   auto end = local_formats.end();
 
-  H264VideoFormat format(CBP,
-      k3_1, CEA640x480p60);
+  H264VideoFormat format;
 
   while(it != end) {
     auto match = std::find(

--- a/libwds/source/cap_negotiation_state.cpp
+++ b/libwds/source/cap_negotiation_state.cpp
@@ -135,13 +135,19 @@ std::unique_ptr<Message> M4Handler::CreateMessage() {
   std::string presentation_Url_1 = "rtsp://" + sender_->GetLocalIPAddress() + "/wfd1.0/streamid=0";
   set_param->payload().add_property(
       std::shared_ptr<Property>(new rtsp::PresentationUrl(presentation_Url_1, "")));
-  set_param->payload().add_property(
-      std::shared_ptr<VideoFormats>(new VideoFormats(
-          NativeVideoFormat(),  // Should be all zeros.
-          false,
-          {source_manager->GetOptimalVideoFormat()})));
-  set_param->payload().add_property(
-      std::shared_ptr<AudioCodecs>(new AudioCodecs({source_manager->GetOptimalAudioFormat()})));
+
+  if (source_manager->GetSessionType() & VideoSession) {
+    set_param->payload().add_property(
+        std::shared_ptr<VideoFormats>(new VideoFormats(
+            NativeVideoFormat(),  // Should be all zeros.
+            false,
+            {source_manager->GetOptimalVideoFormat()})));
+  }
+
+  if (source_manager->GetSessionType() & AudioSession) {
+    set_param->payload().add_property(
+        std::shared_ptr<AudioCodecs>(new AudioCodecs({source_manager->GetOptimalAudioFormat()})));
+  }
 
   return std::unique_ptr<Message>(set_param);
 }


### PR DESCRIPTION
Source should send video(audio) format info only if the established session supports video(audio).