### PR TITLE
Adjust cmake configuration to install things properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project(wds)
+
 enable_testing()
+
+include(GNUInstallDirs)
+
 add_subdirectory(libwds/rtsp)
 add_subdirectory(libwds/common)
 add_subdirectory(libwds/source)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
-project(wds)
+
+project(wds CXX)
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,15 @@ cmake_minimum_required(VERSION 2.8)
 
 project(wds CXX)
 
+set(WDS_VERSION_MAJOR 0)
+set(WDS_VERSION_MINOR 1)
+set(WDS_VERSION_PATCH 0)
+
 enable_testing()
 
 include(GNUInstallDirs)
 
+add_subdirectory(data)
 add_subdirectory(libwds/rtsp)
 add_subdirectory(libwds/common)
 add_subdirectory(libwds/source)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,0 +1,3 @@
+configure_file(wds.pc.in wds.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/wds.pc
+        DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig)

--- a/data/wds.pc.in
+++ b/data/wds.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@LIB_INSTALL_DIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${exec_prefix}/include
  
 Name: @CMAKE_PROJECT_NAME@

--- a/data/wds.pc.in
+++ b/data/wds.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@LIB_INSTALL_DIR@
+includedir=${exec_prefix}/include
+ 
+Name: @CMAKE_PROJECT_NAME@
+Description: Library to build Miracast/WiDi-enabled applications
+Version: @WDS_VERSION_MAJOR@.@WDS_VERSION_MINOR@.@WDS_VERSION_PATCH@
+Libs: -L${libdir} -lwds
+Cflags: -I${includedir}/wds

--- a/data/wds.pc.in
+++ b/data/wds.pc.in
@@ -4,7 +4,7 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${exec_prefix}/include
  
 Name: @CMAKE_PROJECT_NAME@
-Description: Library to build Miracast/WiDi-enabled applications
+Description: Library to build WiFi Display applications
 Version: @WDS_VERSION_MAJOR@.@WDS_VERSION_MINOR@.@WDS_VERSION_PATCH@
 Libs: -L${libdir} -lwds
 Cflags: -I${includedir}/wds

--- a/libwds/CMakeLists.txt
+++ b/libwds/CMakeLists.txt
@@ -10,3 +10,16 @@ add_library(wds
 set_target_properties(wds PROPERTIES SOVERSION 1)
 
 install(TARGETS wds LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+set(PUBLIC_HEADERS
+    public/connector_type.h
+    public/peer.h
+    public/video_format.h
+    public/sink.h
+    public/wds_export.h
+    public/audio_codec.h
+    public/media_manager.h
+    public/source.h
+    public/logging.h)
+
+install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/wds)

--- a/libwds/CMakeLists.txt
+++ b/libwds/CMakeLists.txt
@@ -7,7 +7,9 @@ add_library(wds
            $<TARGET_OBJECTS:wdscommon>
            $<TARGET_OBJECTS:wdssink>
            $<TARGET_OBJECTS:wdssource>)
-set_target_properties(wds PROPERTIES SOVERSION 1)
+set_target_properties(wds PROPERTIES
+    VERSION ${WDS_VERSION_MAJOR}.${WDS_VERSION_MINOR}.${WDS_VERSION_PATCH}
+    SOVERSION ${WDS_VERSION_MAJOR})
 
 install(TARGETS wds LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/libwds/CMakeLists.txt
+++ b/libwds/CMakeLists.txt
@@ -2,7 +2,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fvisibility=hidden")
 set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -std=c99 -Wall")
 
 
-add_library(wds SHARED $<TARGET_OBJECTS:wdsrtsp>
-                       $<TARGET_OBJECTS:wdscommon>
-                       $<TARGET_OBJECTS:wdssink>
-                       $<TARGET_OBJECTS:wdssource>)
+add_library(wds
+    SHARED $<TARGET_OBJECTS:wdsrtsp>
+           $<TARGET_OBJECTS:wdscommon>
+           $<TARGET_OBJECTS:wdssink>
+           $<TARGET_OBJECTS:wdssource>)
+set_target_properties(wds PROPERTIES SOVERSION 1)
+
+install(TARGETS wds LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
To have a real use we need to install the library, public headers and a proper pkg-config file.