### PR TITLE
Move generated parser code to gen folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,18 +9,11 @@ cmake_install.cmake
 install_manifest.txt
 Testing/
 
-# generated source
-libwds/parser/errorscanner.cpp
-libwds/parser/headerscanner.cpp
-libwds/parser/messagescanner.cpp
-libwds/parser/parser.output
-libwds/parser/parser.tab.cpp
-libwds/parser/parser.tab.hpp
-libwds/parser/stack.hh
+# generated rtsp parser sources
+libwds/rtsp/gen
 
 # generated binaries
-libwds/parser/wds
-libwds/parser/test-wds
+libwds/rtsp/test-wds
 sink/sink-test
 p2p/test-ie
 p2p/register-peer-service

--- a/libwds/rtsp/CMakeLists.txt
+++ b/libwds/rtsp/CMakeLists.txt
@@ -3,17 +3,27 @@
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fvisibility=hidden -fPIC")
 set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -std=c99 -Wall")
 
-include_directories ("${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+# Make directory for generated parser files
+set(PARSER_GEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gen")
+file(MAKE_DIRECTORY ${PARSER_GEN_DIR})
+
+include_directories ("${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" "${PARSER_GEN_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
 
 find_package(BISON REQUIRED)
-BISON_TARGET(Parser parser.ypp ${CMAKE_CURRENT_BINARY_DIR}/parser.tab.cpp COMPILE_FLAGS "-d -v -t -r all --debug")
+BISON_TARGET(Parser parser.ypp ${PARSER_GEN_DIR}/parser.tab.cpp)
+
+add_custom_target(remove_exceptions
+    COMMAND ./remove_exceptions.sh ${PARSER_GEN_DIR}/parser.tab.cpp
+    DEPENDS ${BISON_Parser_OUTPUTS}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Removing exceptions")
 
 find_package(FLEX REQUIRED)
-FLEX_TARGET(MessageLexer messagelexer.l  ${CMAKE_CURRENT_BINARY_DIR}/messagescanner.cpp)
+FLEX_TARGET(MessageLexer messagelexer.l  ${PARSER_GEN_DIR}/messagescanner.cpp)
 ADD_FLEX_BISON_DEPENDENCY(MessageLexer Parser)
-FLEX_TARGET(HeaderLexer headerlexer.l  ${CMAKE_CURRENT_BINARY_DIR}/headerscanner.cpp)
+FLEX_TARGET(HeaderLexer headerlexer.l  ${PARSER_GEN_DIR}/headerscanner.cpp)
 ADD_FLEX_BISON_DEPENDENCY(HeaderLexer Parser)
-FLEX_TARGET(ErrorLexer errorlexer.l  ${CMAKE_CURRENT_BINARY_DIR}/errorscanner.cpp)
+FLEX_TARGET(ErrorLexer errorlexer.l  ${PARSER_GEN_DIR}/errorscanner.cpp)
 ADD_FLEX_BISON_DEPENDENCY(ErrorLexer Parser)
 
 add_library(wdsrtsp OBJECT
@@ -31,6 +41,8 @@ add_library(wdsrtsp OBJECT
     standbyresumecapability.cpp standby.cpp idrrequest.cpp connectortype.cpp
     preferreddisplaymode.cpp uibccapability.cpp propertyerrors.cpp scanner.cpp
 )
+
+add_dependencies( wdsrtsp remove_exceptions )
 
 add_executable(test-wds tests.cpp $<TARGET_OBJECTS:wdsrtsp> $<TARGET_OBJECTS:wdscommon>)
 set(LINK_FLAGS ${LINK_FLAGS} "-Wl,-whole-archive")

--- a/libwds/rtsp/driver.h
+++ b/libwds/rtsp/driver.h
@@ -29,7 +29,7 @@
 #include "scanner.h"
 #include "message.h"
 #include "payload.h"
-#include "parser.tab.hpp"
+#include "gen/parser.tab.hpp"
 
 namespace wds {
 namespace rtsp {

--- a/libwds/rtsp/parser.ypp
+++ b/libwds/rtsp/parser.ypp
@@ -1,8 +1,5 @@
 %skeleton "lalr1.cc"
 %require  "3.0"
-%debug 
-%verbose
-%defines
 %define api.namespace {wds::rtsp}
 %define parser_class_name {Parser}
 %start start

--- a/libwds/rtsp/scanner.h
+++ b/libwds/rtsp/scanner.h
@@ -25,7 +25,7 @@
 #include <memory>
 
 #include "driver.h"
-#include "parser.tab.hpp"
+#include "gen/parser.tab.hpp"
 
 class yyFlexLexer;
 


### PR DESCRIPTION
This patch moves all generated parser code under libwds/rtsp/gen