### PR TITLE
Use "Wireless display" term in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-## Wireless Display Software For Linux OS (WDS) - Miracast & WiDi library
+## Wireless Display Software For Linux OS (WDS)
 
-WDS is a set of libraries for developers who want to build Miracast/WiDi-enabled applications on linux. It is still an unreleased work-in-progress but can be tested already.
+WDS is a set of libraries for developers who want to build Wi-Fi Display applications on linux.
 
 WDS consists of:
- * libwds: Main library implements a Miracast-dialect of RTSP that includes the parser, actual negotiation logic for sink and source, and the related data structures. It is not tied to any specific connection manager, media framework or main loop
+ * libwds: Main library implements a Wi-Fi Display dialect of RTSP that includes the parser, actual negotiation logic for sink and source, and the related data structures. It is not tied to any specific connection manager, media framework or main loop
  * network: Supports integration with GLib main loop and GStreamer
  * p2p: Supports integration with Connman Wifi P2P features
 
 
 The source code includes example implementations:
- * _sink:_ Miracast sink that depends on Gstreamer, Connman and GLib mainloop
- * _desktop_source:_ Miracast source that depends on Gstreamer, Connman and GLib mainloop
+ * _sink:_ Wi-Fi Display sink that depends on Gstreamer, Connman and GLib mainloop
+ * _desktop_source:_ Wi-Fi Display source that depends on Gstreamer, Connman and GLib mainloop
 
 More information can be found on the [mailing list](https://lists.01.org/mailman/listinfo/wysiwidi-dev) and the [wiki](https://github.com/01org/wds/wiki).
 
 ### Requirements:
 
-WDS test executables have runtime dependencies on just a few things (mostly GStreamer and GLib), but for successful Miracast sessions the following are adviced:
+WDS test executables have runtime dependencies on just a few things (mostly GStreamer and GLib), but for successful Wi-Fi Display sessions the following are adviced:
  * Wifi adapter from Intel 7260-family or Atheros ath9k
  * [wpa_supplicant](http://w1.fi/wpa_supplicant/): version 2.4 or later, built with	`CONFIG_P2P=y`, `CONFIG_WIFI_DISPLAY=y` and `CONFIG_CTRL_IFACE_DBUS_NEW=y`
  * [connman](https://01.org/connman): version 1.28 (released Feb 1st 2015) or later.


### PR DESCRIPTION
WDS does not implement WiDi and it is not certified Miracast solution,
therefore, Wireless display term should be used.