### PR TITLE
Fix header include guards

### DIFF
--- a/libwds/common/message_handler.h
+++ b/libwds/common/message_handler.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef MESSAGE_HANDLER_H_
-#define MESSAGE_HANDLER_H_
+#ifndef LIBWDS_COMMON_MESSAGE_HANDLER_H_
+#define LIBWDS_COMMON_MESSAGE_HANDLER_H_
 
 #include <cassert>
 #include <list>
@@ -248,4 +248,4 @@ class SequencedMessageSender : public MessageSenderBase {
 };
 
 }  // namespace wds
-#endif // MESSAGE_HANDLER_H_
+#endif // LIBWDS_COMMON_MESSAGE_HANDLER_H_

--- a/libwds/common/rtsp_input_handler.h
+++ b/libwds/common/rtsp_input_handler.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef RTSP_INPUT_HANDLER_H_
-#define RTSP_INPUT_HANDLER_H_
+#ifndef LIBWDS_COMMON_RTSP_INPUT_HANDLER_H_
+#define LIBWDS_COMMON_RTSP_INPUT_HANDLER_H_
 
 #include <memory>
 #include <string>
@@ -53,4 +53,4 @@ class RTSPInputHandler {
 
 }
 
-#endif // RTSP_INPUT_HANDLER_H_
+#endif // LIBWDS_COMMON_RTSP_INPUT_HANDLER_H_

--- a/libwds/public/audio_codec.h
+++ b/libwds/public/audio_codec.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef AUDIO_CODEC_H_
-#define AUDIO_CODEC_H_
+#ifndef LIBWDS_PUBLIC_AUDIO_CODEC_H_
+#define LIBWDS_PUBLIC_AUDIO_CODEC_H_
 
 #include <bitset>
 
@@ -70,4 +70,4 @@ struct AudioCodec {
 
 }  // namespace wds
 
-#endif  // AUDIO_CODEC_H_
+#endif  // LIBWDS_PUBLIC_AUDIO_CODEC_H_

--- a/libwds/public/connector_type.h
+++ b/libwds/public/connector_type.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef CONNECTOR_TYPE_H_
-#define CONNECTOR_TYPE_H_
+#ifndef LIBWDS_PUBLIC_CONNECTOR_TYPE_H_
+#define LIBWDS_PUBLIC_CONNECTOR_TYPE_H_
 
 namespace wds {
 
@@ -33,4 +33,4 @@ enum ConnectorType {
 
 }  // namespace wds
 
-#endif  // CONNECTOR_TYPE_H_
+#endif  // LIBWDS_PUBLIC_CONNECTOR_TYPE_H_

--- a/libwds/public/logging.h
+++ b/libwds/public/logging.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef LOGGING_H_
-#define LOGGING_H_
+#ifndef LIBWDS_PUBLIC_LOGGING_H_
+#define LIBWDS_PUBLIC_LOGGING_H_
 
 #include <cstdarg>
 
@@ -96,4 +96,4 @@ class WDS_EXPORT LogSystem {
 #define WDS_WARNING(...) (*wds::LogSystem::warning_func())(__VA_ARGS__);
 #define WDS_ERROR(...) (*wds::LogSystem::error_func())(__VA_ARGS__);
 
-#endif // LOGGING_H_
+#endif // LIBWDS_PUBLIC_LOGGING_H_

--- a/libwds/public/media_manager.h
+++ b/libwds/public/media_manager.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef MEDIA_MANAGER_H_
-#define MEDIA_MANAGER_H_
+#ifndef LIBWDS_PUBLIC_MEDIA_MANAGER_H_
+#define LIBWDS_PUBLIC_MEDIA_MANAGER_H_
 
 #include <string>
 #include <vector>
@@ -252,5 +252,5 @@ inline SinkMediaManager* ToSinkMediaManager(MediaManager* mng) {
 
 }  // namespace wds
 
-#endif // MEDIA_MANAGER_H_
+#endif // LIBWDS_PUBLIC_MEDIA_MANAGER_H_
 

--- a/libwds/public/peer.h
+++ b/libwds/public/peer.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef PEER_H_
-#define PEER_H_
+#ifndef LIBWDS_PUBLIC_PEER_H_
+#define LIBWDS_PUBLIC_PEER_H_
 
 #include <string>
 
@@ -161,4 +161,4 @@ class Peer {
 
 }
 
-#endif // PEER_H_
+#endif // LIBWDS_PUBLIC_PEER_H_

--- a/libwds/public/sink.h
+++ b/libwds/public/sink.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef SINK_H_
-#define SINK_H_
+#ifndef LIBWDS_PUBLIC_SINK_H_
+#define LIBWDS_PUBLIC_SINK_H_
 
 #include "peer.h"
 
@@ -46,4 +46,4 @@ class Sink : public Peer {
 
 }
 
-#endif // SINK_H_
+#endif // LIBWDS_PUBLIC_SINK_H_

--- a/libwds/public/source.h
+++ b/libwds/public/source.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef SOURCE_H_
-#define SOURCE_H_
+#ifndef LIBWDS_PUBLIC_SOURCE_H_
+#define LIBWDS_PUBLIC_SOURCE_H_
 
 #include "peer.h"
 
@@ -47,4 +47,4 @@ class Source : public Peer {
 
 }
 
-#endif // SOURCE_H_
+#endif // LIBWDS_PUBLIC_SOURCE_H_

--- a/libwds/public/video_format.h
+++ b/libwds/public/video_format.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef VIDEO_FORMAT_H_
-#define VIDEO_FORMAT_H_
+#ifndef LIBWDS_PUBLIC_VIDEO_FORMAT_H_
+#define LIBWDS_PUBLIC_VIDEO_FORMAT_H_
 
 #include <bitset>
 #include <vector>
@@ -215,4 +215,4 @@ WDS_EXPORT H264VideoFormat FindOptimalVideoFormat(
 
 }  // namespace wds
 
-#endif  // VIDEO_FORMAT_H_
+#endif  // LIBWDS_PUBLIC_VIDEO_FORMAT_H_

--- a/libwds/public/wds_export.h
+++ b/libwds/public/wds_export.h
@@ -19,9 +19,9 @@
  * 02110-1301 USA
  */
 
-#ifndef WDS_EXPORT_H_
-#define WDS_EXPORT_H_
+#ifndef LIBWDS_PUBLIC_WDS_EXPORT_H_
+#define LIBWDS_PUBLIC_WDS_EXPORT_H_
 
 #define WDS_EXPORT __attribute__((visibility("default")))
 
-#endif  // WDS_EXPORT_H_
+#endif  // LIBWDS_PUBLIC_WDS_EXPORT_H_

--- a/libwds/rtsp/audiocodecs.h
+++ b/libwds/rtsp/audiocodecs.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef AUDIOCODECS_H_
-#define AUDIOCODECS_H_
+#ifndef LIBWDS_RTSP_AUDIOCODECS_H_
+#define LIBWDS_RTSP_AUDIOCODECS_H_
 
 #include "property.h"
 #include "libwds/public/audio_codec.h"
@@ -47,4 +47,4 @@ class AudioCodecs: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // AUDIOCODECS_H_
+#endif  // LIBWDS_RTSP_AUDIOCODECS_H_

--- a/libwds/rtsp/avformatchangetiming.h
+++ b/libwds/rtsp/avformatchangetiming.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef AVFORMATCHANGETIMING_H_
-#define AVFORMATCHANGETIMING_H_
+#ifndef LIBWDS_RTSP_AVFORMATCHANGETIMING_H_
+#define LIBWDS_RTSP_AVFORMATCHANGETIMING_H_
 
 #include "property.h"
 
@@ -46,4 +46,4 @@ public:
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // AVFORMATCHANGETIMING_H_
+#endif  // LIBWDS_RTSP_AVFORMATCHANGETIMING_H_

--- a/libwds/rtsp/clientrtpports.h
+++ b/libwds/rtsp/clientrtpports.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef CLIENTRTPPORTS_H_
-#define CLIENTRTPPORTS_H_
+#ifndef LIBWDS_RTSP_CLIENTRTPPORTS_H_
+#define LIBWDS_RTSP_CLIENTRTPPORTS_H_
 
 #include "property.h"
 
@@ -45,4 +45,4 @@ class ClientRtpPorts: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // CLIENTRTPPORTS_H_
+#endif  // LIBWDS_RTSP_CLIENTRTPPORTS_H_

--- a/libwds/rtsp/connectortype.h
+++ b/libwds/rtsp/connectortype.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef CONNECTORTYPE_H_
-#define CONNECTORTYPE_H_
+#ifndef LIBWDS_RTSP_CONNECTORTYPE_H_
+#define LIBWDS_RTSP_CONNECTORTYPE_H_
 
 #include "property.h"
 #include "libwds/public/connector_type.h"
@@ -45,4 +45,4 @@ class ConnectorType: public Property {
 
 }  // namespace rtsp
 }  // namespace wds
-#endif  // CONNECTORTYPE_H_
+#endif  // LIBWDS_RTSP_CONNECTORTYPE_H_

--- a/libwds/rtsp/constants.h
+++ b/libwds/rtsp/constants.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef CONSTANTS_H_
-#define CONSTANTS_H_
+#ifndef LIBWDS_RTSP_CONSTANTS_H_
+#define LIBWDS_RTSP_CONSTANTS_H_
 
 namespace wds {
 namespace rtsp {
@@ -119,4 +119,4 @@ enum RTSPStatusCode {
 } // namespace rtsp
 } // namespace wds
 
-#endif // CONSTANTS_H_
+#endif // LIBWDS_RTSP_CONSTANTS_H_

--- a/libwds/rtsp/contentprotection.h
+++ b/libwds/rtsp/contentprotection.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef CONTENTPROTECTION_H_
-#define CONTENTPROTECTION_H_
+#ifndef LIBWDS_RTSP_CONTENTPROTECTION_H_
+#define LIBWDS_RTSP_CONTENTPROTECTION_H_
 
 #include "property.h"
 
@@ -52,4 +52,4 @@ class ContentProtection: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // CONTENTPROTECTION_H_
+#endif  // LIBWDS_RTSP_CONTENTPROTECTION_H_

--- a/libwds/rtsp/coupledsink.h
+++ b/libwds/rtsp/coupledsink.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef COUPLEDSINK_H_
-#define COUPLEDSINK_H_
+#ifndef LIBWDS_RTSP_COUPLEDSINK_H_
+#define LIBWDS_RTSP_COUPLEDSINK_H_
 
 #include "property.h"
 
@@ -46,4 +46,4 @@ class CoupledSink: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // COUPLEDSINK_H_
+#endif  // LIBWDS_RTSP_COUPLEDSINK_H_

--- a/libwds/rtsp/displayedid.h
+++ b/libwds/rtsp/displayedid.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef DISPLAYEDID_H_
-#define DISPLAYEDID_H_
+#ifndef LIBWDS_RTSP_DISPLAYEDID_H_
+#define LIBWDS_RTSP_DISPLAYEDID_H_
 
 #include "property.h"
 
@@ -46,4 +46,4 @@ class DisplayEdid: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // DISPLAYEDID_H_
+#endif  // LIBWDS_RTSP_DISPLAYEDID_H_

--- a/libwds/rtsp/driver.h
+++ b/libwds/rtsp/driver.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef DRIVER_H_
-#define DRIVER_H_
+#ifndef LIBWDS_RTSP_DRIVER_H_
+#define LIBWDS_RTSP_DRIVER_H_
 
 #include <string>
 #include <memory>
@@ -45,4 +45,4 @@ class Driver {
 int wds_lex(YYSTYPE* yylval, void* scanner, std::unique_ptr<wds::rtsp::Message>& message);
 void wds_error (void* scanner, std::unique_ptr<wds::rtsp::Message>& message, const char* error_message);
 
-#endif  // DRIVER_H_
+#endif  // LIBWDS_RTSP_DRIVER_H_

--- a/libwds/rtsp/formats3d.h
+++ b/libwds/rtsp/formats3d.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef FORMATS3D_H_
-#define FORMATS3D_H_
+#ifndef LIBWDS_RTSP_FORMATS3D_H_
+#define LIBWDS_RTSP_FORMATS3D_H_
 
 #include "property.h"
 
@@ -87,4 +87,4 @@ class Formats3d: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // FORMATS3D_H_
+#endif  // LIBWDS_RTSP_FORMATS3D_H_

--- a/libwds/rtsp/genericproperty.h
+++ b/libwds/rtsp/genericproperty.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef GENERIC_PROPERTY_H_
-#define GENERIC_PROPERTY_H_
+#ifndef LIBWDS_RTSP_GENERIC_PROPERTY_H_
+#define LIBWDS_RTSP_GENERIC_PROPERTY_H_
 
 #include "property.h"
 
@@ -47,4 +47,4 @@ class GenericProperty: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // GENERIC_PROPERTY_H_
+#endif  // LIBWDS_RTSP_GENERIC_PROPERTY_H_

--- a/libwds/rtsp/getparameter.h
+++ b/libwds/rtsp/getparameter.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef GETPARAMETER_H_
-#define GETPARAMETER_H_
+#ifndef LIBWDS_RTSP_GETPARAMETER_H_
+#define LIBWDS_RTSP_GETPARAMETER_H_
 
 #include "message.h"
 
@@ -38,4 +38,4 @@ class GetParameter : public Request {
 } // namespace rtsp
 } // namespace wds
 
-#endif // GETPARAMETER_H_
+#endif // LIBWDS_RTSP_GETPARAMETER_H_

--- a/libwds/rtsp/header.h
+++ b/libwds/rtsp/header.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef HEADER_H_
-#define HEADER_H_
+#ifndef LIBWDS_RTSP_HEADER_H_
+#define LIBWDS_RTSP_HEADER_H_
 
 #include <string>
 #include <vector>
@@ -86,4 +86,4 @@ class Header {
 } // namespace rtsp
 } // namespace wds
 
-#endif // HEADER_H_
+#endif // LIBWDS_RTSP_HEADER_H_

--- a/libwds/rtsp/i2c.h
+++ b/libwds/rtsp/i2c.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef I2C_H_
-#define I2C_H_
+#ifndef LIBWDS_RTSP_I2C_H_
+#define LIBWDS_RTSP_I2C_H_
 
 #include "property.h"
 
@@ -44,4 +44,4 @@ class I2C: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // I2C_H_
+#endif  // LIBWDS_RTSP_I2C_H_

--- a/libwds/rtsp/idrrequest.h
+++ b/libwds/rtsp/idrrequest.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef IDRREQUEST_H_
-#define IDRREQUEST_H_
+#ifndef LIBWDS_RTSP_IDRREQUEST_H_
+#define LIBWDS_RTSP_IDRREQUEST_H_
 
 #include "property.h"
 
@@ -39,4 +39,4 @@ public:
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // IDRREQUEST_H_
+#endif  // LIBWDS_RTSP_IDRREQUEST_H_

--- a/libwds/rtsp/macros.h
+++ b/libwds/rtsp/macros.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef MACROS_H_
-#define MACROS_H_
+#ifndef LIBWDS_RTSP_MACROS_H_
+#define LIBWDS_RTSP_MACROS_H_
 
 #include <stdio.h>
 
@@ -53,5 +53,5 @@
   char NAME[17]; \
   std::snprintf(NAME, sizeof(NAME), "%016llX", PROPERTY) \
 
-#endif  // MACROS_H_
+#endif  // LIBWDS_RTSP_MACROS_H_
 

--- a/libwds/rtsp/message.h
+++ b/libwds/rtsp/message.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef MESSAGE_H_
-#define MESSAGE_H_
+#ifndef LIBWDS_RTSP_MESSAGE_H_
+#define LIBWDS_RTSP_MESSAGE_H_
 
 #include <memory>
 
@@ -112,4 +112,4 @@ inline Request* ToRequest(Message* message) {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // MESSAGE_H_
+#endif  // LIBWDS_RTSP_MESSAGE_H_

--- a/libwds/rtsp/options.h
+++ b/libwds/rtsp/options.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef OPTIONS_H_
-#define OPTIONS_H_
+#ifndef LIBWDS_RTSP_OPTIONS_H_
+#define LIBWDS_RTSP_OPTIONS_H_
 
 #include "message.h"
 
@@ -38,4 +38,4 @@ class Options: public Request {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif // OPTIONS_H_
+#endif // LIBWDS_RTSP_OPTIONS_H_

--- a/libwds/rtsp/pause.h
+++ b/libwds/rtsp/pause.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef PAUSE_H_
-#define PAUSE_H_
+#ifndef LIBWDS_RTSP_PAUSE_H_
+#define LIBWDS_RTSP_PAUSE_H_
 
 #include "message.h"
 
@@ -38,4 +38,4 @@ class Pause : public Request {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif // PAUSE_H_
+#endif // LIBWDS_RTSP_PAUSE_H_

--- a/libwds/rtsp/payload.h
+++ b/libwds/rtsp/payload.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef PAYLOAD_H_
-#define PAYLOAD_H_
+#ifndef LIBWDS_RTSP_PAYLOAD_H_
+#define LIBWDS_RTSP_PAYLOAD_H_
 
 #include <map>
 #include <memory>
@@ -72,4 +72,4 @@ class Payload {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif // PAYLOAD_H_
+#endif // LIBWDS_RTSP_PAYLOAD_H_

--- a/libwds/rtsp/play.h
+++ b/libwds/rtsp/play.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef PLAY_H_
-#define PLAY_H_
+#ifndef LIBWDS_RTSP_PLAY_H_
+#define LIBWDS_RTSP_PLAY_H_
 
 #include "message.h"
 
@@ -37,4 +37,4 @@ class Play : public Request {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif // PLAY_H_
+#endif // LIBWDS_RTSP_PLAY_H_

--- a/libwds/rtsp/preferreddisplaymode.h
+++ b/libwds/rtsp/preferreddisplaymode.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef PREFERREDDISPLAYMODE_H_
-#define PREFERREDDISPLAYMODE_H_
+#ifndef LIBWDS_RTSP_PREFERREDDISPLAYMODE_H_
+#define LIBWDS_RTSP_PREFERREDDISPLAYMODE_H_
 
 #include "property.h"
 
@@ -75,4 +75,4 @@ class PreferredDisplayMode: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // PREFERREDDISPLAYMODE_H_
+#endif  // LIBWDS_RTSP_PREFERREDDISPLAYMODE_H_

--- a/libwds/rtsp/presentationurl.h
+++ b/libwds/rtsp/presentationurl.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef PRESENTATIONURL_H_
-#define PRESENTATIONURL_H_
+#ifndef LIBWDS_RTSP_PRESENTATIONURL_H_
+#define LIBWDS_RTSP_PRESENTATIONURL_H_
 
 #include "property.h"
 
@@ -46,4 +46,4 @@ class PresentationUrl: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // PRESENTATIONURL_H_
+#endif  // LIBWDS_RTSP_PRESENTATIONURL_H_

--- a/libwds/rtsp/property.h
+++ b/libwds/rtsp/property.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef PROPERTY_H_
-#define PROPERTY_H_
+#ifndef LIBWDS_RTSP_PROPERTY_H_
+#define LIBWDS_RTSP_PROPERTY_H_
 
 #include <string>
 #include <map>
@@ -53,4 +53,4 @@ std::string GetPropertyName(PropertyType type);
 }  // namespace wds
 }  // namespace rtsp
 
-#endif  // PROPERTY_H_
+#endif  // LIBWDS_RTSP_PROPERTY_H_

--- a/libwds/rtsp/propertyerrors.h
+++ b/libwds/rtsp/propertyerrors.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef PROPERTYERRORS_H_
-#define PROPERTYERRORS_H_
+#ifndef LIBWDS_RTSP_PROPERTYERRORS_H_
+#define LIBWDS_RTSP_PROPERTYERRORS_H_
 
 #include <string>
 #include <vector>
@@ -51,4 +51,4 @@ class PropertyErrors {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // PROPERTYERRORS_H_
+#endif  // LIBWDS_RTSP_PROPERTYERRORS_H_

--- a/libwds/rtsp/reply.h
+++ b/libwds/rtsp/reply.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef REPLY_H_
-#define REPLY_H_
+#ifndef LIBWDS_RTSP_REPLY_H_
+#define LIBWDS_RTSP_REPLY_H_
 
 #include "message.h"
 
@@ -45,4 +45,4 @@ class Reply: public Message {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // REPLY_H_
+#endif  // LIBWDS_RTSP_REPLY_H_

--- a/libwds/rtsp/route.h
+++ b/libwds/rtsp/route.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef ROUTE_H_
-#define ROUTE_H_
+#ifndef LIBWDS_RTSP_ROUTE_H_
+#define LIBWDS_RTSP_ROUTE_H_
 
 #include "property.h"
 
@@ -49,4 +49,4 @@ class Route: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // ROUTE_H_
+#endif  // LIBWDS_RTSP_ROUTE_H_

--- a/libwds/rtsp/setparameter.h
+++ b/libwds/rtsp/setparameter.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef SETPARAMETER_H_
-#define SETPARAMETER_H_
+#ifndef LIBWDS_RTSP_SETPARAMETER_H_
+#define LIBWDS_RTSP_SETPARAMETER_H_
 
 #include "message.h"
 
@@ -37,4 +37,4 @@ class SetParameter : public Request {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif // SETPARAMETER_H_
+#endif // LIBWDS_RTSP_SETPARAMETER_H_

--- a/libwds/rtsp/setup.h
+++ b/libwds/rtsp/setup.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef SETUP_H_
-#define SETUP_H_
+#ifndef LIBWDS_RTSP_SETUP_H_
+#define LIBWDS_RTSP_SETUP_H_
 
 #include "message.h"
 
@@ -38,4 +38,4 @@ class Setup : public Request {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif // SETUP_H_
+#endif // LIBWDS_RTSP_SETUP_H_

--- a/libwds/rtsp/standby.h
+++ b/libwds/rtsp/standby.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef STANDBY_H_
-#define STANDBY_H_
+#ifndef LIBWDS_RTSP_STANDBY_H_
+#define LIBWDS_RTSP_STANDBY_H_
 
 #include "property.h"
 
@@ -38,4 +38,4 @@ public:
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // STANDBY_H_
+#endif  // LIBWDS_RTSP_STANDBY_H_

--- a/libwds/rtsp/standbyresumecapability.h
+++ b/libwds/rtsp/standbyresumecapability.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef STANDBYRESUMECAPABILITY_H_
-#define STANDBYRESUMECAPABILITY_H_
+#ifndef LIBWDS_RTSP_STANDBYRESUMECAPABILITY_H_
+#define LIBWDS_RTSP_STANDBYRESUMECAPABILITY_H_
 
 #include "property.h"
 
@@ -39,4 +39,4 @@ public:
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // STANDBYRESUMECAPABILITY_H_
+#endif  // LIBWDS_RTSP_STANDBYRESUMECAPABILITY_H_

--- a/libwds/rtsp/teardown.h
+++ b/libwds/rtsp/teardown.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef TEARDOWN_H_
-#define TEARDOWN_H_
+#ifndef LIBWDS_RTSP_TEARDOWN_H_
+#define LIBWDS_RTSP_TEARDOWN_H_
 
 #include "message.h"
 
@@ -38,4 +38,4 @@ class Teardown : public Request {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif // TEARDOWN_H_
+#endif // LIBWDS_RTSP_TEARDOWN_H_

--- a/libwds/rtsp/transportheader.h
+++ b/libwds/rtsp/transportheader.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef TRANSPORT_HEADER_H_
-#define TRANSPORT_HEADER_H_
+#ifndef LIBWDS_RTSP_TRANSPORT_HEADER_H_
+#define LIBWDS_RTSP_TRANSPORT_HEADER_H_
 
 #include <string>
 
@@ -57,4 +57,4 @@ class TransportHeader {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif // TRANSPORT_HEADER_H_
+#endif // LIBWDS_RTSP_TRANSPORT_HEADER_H_

--- a/libwds/rtsp/triggermethod.h
+++ b/libwds/rtsp/triggermethod.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef TRIGGERMETHOD_H_
-#define TRIGGERMETHOD_H_
+#ifndef LIBWDS_RTSP_TRIGGERMETHOD_H_
+#define LIBWDS_RTSP_TRIGGERMETHOD_H_
 
 #include "property.h"
 
@@ -51,4 +51,4 @@ class TriggerMethod : public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // TRIGGERMETHOD_H_
+#endif  // LIBWDS_RTSP_TRIGGERMETHOD_H_

--- a/libwds/rtsp/uibccapability.h
+++ b/libwds/rtsp/uibccapability.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef UIBCCAPABILITY_H_
-#define UIBCCAPABILITY_H_
+#ifndef LIBWDS_RTSP_UIBCCAPABILITY_H_
+#define LIBWDS_RTSP_UIBCCAPABILITY_H_
 
 #include "property.h"
 
@@ -82,4 +82,4 @@ class UIBCCapability: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // UIBCCAPABILITY_H_
+#endif  // LIBWDS_RTSP_UIBCCAPABILITY_H_

--- a/libwds/rtsp/uibcsetting.h
+++ b/libwds/rtsp/uibcsetting.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef UIBCSETTING_H_
-#define UIBCSETTING_H_
+#ifndef LIBWDS_RTSP_UIBCSETTING_H_
+#define LIBWDS_RTSP_UIBCSETTING_H_
 
 #include "property.h"
 
@@ -42,4 +42,4 @@ class UIBCSetting : public Property {
 
 }  // namespace rtsp
 }  // namespace wds
-#endif  // UIBCSETTING_H_
+#endif  // LIBWDS_RTSP_UIBCSETTING_H_

--- a/libwds/rtsp/videoformats.h
+++ b/libwds/rtsp/videoformats.h
@@ -20,8 +20,8 @@
  */
 
 
-#ifndef VIDEOFORMATS_H_
-#define VIDEOFORMATS_H_
+#ifndef LIBWDS_RTSP_VIDEOFORMATS_H_
+#define LIBWDS_RTSP_VIDEOFORMATS_H_
 
 #include "property.h"
 #include "libwds/public/video_format.h"
@@ -92,4 +92,4 @@ class VideoFormats: public Property {
 }  // namespace rtsp
 }  // namespace wds
 
-#endif  // VIDEOFORMATS_H_
+#endif  // LIBWDS_RTSP_VIDEOFORMATS_H_

--- a/libwds/sink/cap_negotiation_state.h
+++ b/libwds/sink/cap_negotiation_state.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef CAP_NEGOTIATION_STATE_H_
-#define CAP_NEGOTIATION_STATE_H_
+#ifndef LIBWDS_SINK_CAP_NEGOTIATION_STATE_H_
+#define LIBWDS_SINK_CAP_NEGOTIATION_STATE_H_
 
 #include "libwds/common/message_handler.h"
 
@@ -49,4 +49,4 @@ class M3Handler final : public MessageReceiver<rtsp::Request::M3> {
 }  // namespace sink
 }  // namespace wds
 
-#endif // CAP_NEGOTIATION_STATE_H_
+#endif // LIBWDS_SINK_CAP_NEGOTIATION_STATE_H_

--- a/libwds/sink/init_state.h
+++ b/libwds/sink/init_state.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef INIT_STATE_H_
-#define INIT_STATE_H_
+#ifndef LIBWDS_SINK_INIT_STATE_H_
+#define LIBWDS_SINK_INIT_STATE_H_
 
 #include "libwds/common/message_handler.h"
 
@@ -37,4 +37,4 @@ class InitState : public MessageSequenceHandler {
 }  // sink
 }  // wds
 
-#endif // INIT_STATE_H_
+#endif // LIBWDS_SINK_INIT_STATE_H_

--- a/libwds/sink/session_state.h
+++ b/libwds/sink/session_state.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef SESSION_STATE_H_
-#define SESSION_STATE_H_
+#ifndef LIBWDS_SINK_SESSION_STATE_H_
+#define LIBWDS_SINK_SESSION_STATE_H_
 
 #include "libwds/common/message_handler.h"
 
@@ -59,4 +59,4 @@ class SessionState : public MessageSequenceWithOptionalSetHandler {
 }  // sink
 }  // wds
 
-#endif // SESSION_STATE_H_
+#endif // LIBWDS_SINK_SESSION_STATE_H_

--- a/libwds/sink/streaming_state.h
+++ b/libwds/sink/streaming_state.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef STREAMING_STATE_H_
-#define STREAMING_STATE_H_
+#ifndef LIBWDS_SINK_STREAMING_STATE_H_
+#define LIBWDS_SINK_STREAMING_STATE_H_
 
 #include "libwds/common/message_handler.h"
 
@@ -42,4 +42,4 @@ class TeardownHandler : public MessageSequenceHandler {
 }  // sink
 }  // wds
 
-#endif // STREAMING_STATE_H_
+#endif // LIBWDS_SINK_STREAMING_STATE_H_

--- a/libwds/source/cap_negotiation_state.h
+++ b/libwds/source/cap_negotiation_state.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef CAP_NEGOTIATION_STATE_H_
-#define CAP_NEGOTIATION_STATE_H_
+#ifndef LIBWDS_SOURCE_CAP_NEGOTIATION_STATE_H_
+#define LIBWDS_SOURCE_CAP_NEGOTIATION_STATE_H_
 
 #include "libwds/common/message_handler.h"
 
@@ -38,4 +38,4 @@ class CapNegotiationState : public MessageSequenceHandler {
 }  // source
 }  // wds
 
-#endif // CAP_NEGOTIATION_STATE_H_
+#endif // LIBWDS_SOURCE_CAP_NEGOTIATION_STATE_H_

--- a/libwds/source/init_state.h
+++ b/libwds/source/init_state.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef INIT_STATE_H_
-#define INIT_STATE_H_
+#ifndef LIBWDS_SOURCE_INIT_STATE_H_
+#define LIBWDS_SOURCE_INIT_STATE_H_
 
 #include "libwds/common/message_handler.h"
 
@@ -38,4 +38,4 @@ class InitState : public MessageSequenceHandler {
 }  // source
 }  // wds
 
-#endif // INIT_STATE_H_
+#endif // LIBWDS_SOURCE_INIT_STATE_H_

--- a/libwds/source/session_state.h
+++ b/libwds/source/session_state.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef SESSION_STATE_H_
-#define SESSION_STATE_H_
+#ifndef LIBWDS_SOURCE_SESSION_STATE_H_
+#define LIBWDS_SOURCE_SESSION_STATE_H_
 
 #include "libwds/common/message_handler.h"
 
@@ -56,4 +56,4 @@ class M16Sender final : public OptionalMessageSender<rtsp::Request::M16> {
 }  // source
 }  // wds
 
-#endif // SESSION_STATE_H_
+#endif // LIBWDS_SOURCE_SESSION_STATE_H_

--- a/libwds/source/streaming_state.h
+++ b/libwds/source/streaming_state.h
@@ -19,8 +19,8 @@
  * 02110-1301 USA
  */
 
-#ifndef STREAMING_STATE_H_
-#define STREAMING_STATE_H_
+#ifndef LIBWDS_SOURCE_STREAMING_STATE_H_
+#define LIBWDS_SOURCE_STREAMING_STATE_H_
 
 #include "libwds/common/message_handler.h"
 
@@ -38,4 +38,4 @@ class StreamingState : public MessageSequenceWithOptionalSetHandler {
 }  // source
 }  // wds
 
-#endif // STREAMING_STATE_H_
+#endif // LIBWDS_SOURCE_STREAMING_STATE_H_


### PR DESCRIPTION
Fix header include guards by adding folder name.
libwds = root of libwds related header files.