### PR TITLE
Split rtsp::Payload

### DIFF
--- a/libwds/rtsp/genericproperty.cpp
+++ b/libwds/rtsp/genericproperty.cpp
@@ -39,8 +39,12 @@ GenericProperty::GenericProperty(const std::string& key, const std::string& valu
 GenericProperty::~GenericProperty() {
 }
 
-std::string GenericProperty::ToString() const{
+std::string GenericProperty::ToString() const {
   return key_ + ": " + value_;
+}
+
+std::string GenericProperty::GetName() const {
+  return key_;
 }
 
 }  // namespace rtsp

--- a/libwds/rtsp/genericproperty.h
+++ b/libwds/rtsp/genericproperty.h
@@ -29,19 +29,21 @@ namespace wds {
 namespace rtsp {
 
 class GenericProperty: public Property {
-  public:
-    GenericProperty();
-    GenericProperty(const std::string& key, const std::string& value);
+ public:
+  GenericProperty();
+  GenericProperty(const std::string& key, const std::string& value);
 
-    ~GenericProperty() override;
+  ~GenericProperty() override;
 
-    const std::string& key () const { return key_; }
-    const std::string& value () const { return value_; }
+  const std::string& key() const { return key_; }
+  const std::string& value() const { return value_; }
 
-    std::string ToString() const override;
-  private:
-    std::string key_;
-    std::string value_;
+  std::string ToString() const override;
+  std::string GetName() const override;
+
+ private:
+  std::string key_;
+  std::string value_;
 };
 
 }  // namespace rtsp

--- a/libwds/rtsp/message.cpp
+++ b/libwds/rtsp/message.cpp
@@ -49,12 +49,6 @@ Header& Message::header() {
   return *header_;
 }
 
-Payload& Message::payload() {
-  if (!payload_)
-    payload_.reset(new Payload());
-  return *payload_;
-}
-
 std::string Message::ToString() const {
   std::string ret;
   if (payload_)

--- a/libwds/rtsp/message.h
+++ b/libwds/rtsp/message.h
@@ -56,7 +56,7 @@ class Message {
     payload_ = std::move(payload);
   }
 
-  Payload& payload();
+  Payload* payload() { return payload_.get(); }
 
   virtual std::string ToString() const;
 

--- a/libwds/rtsp/parser.ypp
+++ b/libwds/rtsp/parser.ypp
@@ -545,20 +545,26 @@ payload: {
 wfd_parameter_list:
     wfd_parameter_list wfd_parameter {
       UNUSED_TOKEN($$);
-      $1->add_get_parameter_property($2);
+      if (auto payload = ToGetParameterPayload($1))
+        payload->AddRequestProperty($2);
+      else
+        YYERROR;
     }
   | wfd_parameter {
-      $$ = new wds::rtsp::Payload();
-      $$->add_get_parameter_property($1);
+      $$ = new wds::rtsp::GetParameterPayload();
+      wds::rtsp::ToGetParameterPayload($$)->AddRequestProperty($1);
     }
   | wfd_parameter_list WFD_GENERIC_PROPERTY {
       UNUSED_TOKEN($$);
-      $1->add_get_parameter_property(*$2);
+      if (auto payload = ToGetParameterPayload($1))
+        payload->AddRequestProperty(*$2);
+      else
+        YYERROR;
       DELETE_TOKEN($2);
     }
   | WFD_GENERIC_PROPERTY {
-      $$ = new wds::rtsp::Payload();
-      $$->add_get_parameter_property(*$1);
+      $$ = new wds::rtsp::GetParameterPayload();
+      wds::rtsp::ToGetParameterPayload($$)->AddRequestProperty(*$1);
       DELETE_TOKEN($1);
     }
   ;
@@ -675,21 +681,27 @@ wfd_property_errors:
 
 wfd_property_error_map:
     wfd_property_errors {
-      $$ = new wds::rtsp::Payload();
-      $$->add_property_error(std::shared_ptr<wds::rtsp::PropertyErrors>($1));
+      $$ = new wds::rtsp::PropertyErrorPayload();
+      ToPropertyErrorPayload($$)->AddPropertyError(std::shared_ptr<wds::rtsp::PropertyErrors>($1));
     }
   | wfd_property_error_map wfd_property_errors {
-      $1->add_property_error(std::shared_ptr<wds::rtsp::PropertyErrors>($2));
+      if (auto payload = ToPropertyErrorPayload($1))
+        payload->AddPropertyError(std::shared_ptr<wds::rtsp::PropertyErrors>($2));
+      else
+        YYERROR;
     }
   ;
 
 wdf_property_map:
     wfd_property {
-      $$ = new wds::rtsp::Payload();
-      $$->add_property(std::shared_ptr<wds::rtsp::Property>($1));
+      $$ = new wds::rtsp::PropertyMapPayload();
+      ToPropertyMapPayload($$)->AddProperty(std::shared_ptr<wds::rtsp::Property>($1));
     }
   | wdf_property_map wfd_property {
-      $1->add_property(std::shared_ptr<wds::rtsp::Property>($2));
+      if (auto payload = ToPropertyMapPayload($1))
+        payload->AddProperty(std::shared_ptr<wds::rtsp::Property>($2));
+      else
+        YYERROR;
     } 
   ;
 

--- a/libwds/rtsp/payload.h
+++ b/libwds/rtsp/payload.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include "libwds/public/logging.h"
+
 #include "property.h"
 #include "genericproperty.h"
 #include "propertyerrors.h"
@@ -40,34 +42,100 @@ using PropertyErrorMap = std::map<std::string, std::shared_ptr<PropertyErrors>>;
 
 class Payload {
  public:
-  Payload();
-  explicit Payload(const std::vector<std::string>& request_properties);
-  explicit Payload(const PropertyMap& properties);
-  explicit Payload(const PropertyErrorMap& property_errors);
+  enum Type {
+    Properties,
+    Requests,
+    Errors
+  };
+
   virtual ~Payload();
+  virtual std::string ToString() const = 0;
 
-  std::shared_ptr<Property> get_property(const std::string& name) const;
-  std::shared_ptr<Property> get_property(PropertyType type) const;
-  bool has_property(PropertyType type) const;
-  void add_property(const std::shared_ptr<Property>& property);
-  const PropertyMap& properties() const;
+  Type type() const { return type_; }
 
-  void add_get_parameter_property(const PropertyType& property);
-  void add_get_parameter_property(const std::string& generic_property);
-  const std::vector<std::string>& get_parameter_properties() const;
+ protected:
+  explicit Payload(Type type) : type_(type) {}
+  Type type_;
+};
 
-  std::shared_ptr<PropertyErrors> get_property_error(const std::string& name) const;
-  std::shared_ptr<PropertyErrors> get_property_error(PropertyType type) const;
-  void add_property_error(const std::shared_ptr<PropertyErrors>& errors);
-  const PropertyErrorMap& property_errors() const;
+class PropertyMapPayload : public Payload {
+ public:
+  PropertyMapPayload() : Payload(Payload::Properties) {}
 
-  std::string ToString() const;
+  ~PropertyMapPayload() override;
+
+  std::shared_ptr<Property> GetProperty(const std::string& name) const;
+  std::shared_ptr<Property> GetProperty(PropertyType type) const;
+  bool HasProperty(PropertyType type) const;
+  void AddProperty(const std::shared_ptr<Property>& property);
+  const PropertyMap& properties() const { return properties_; }
+
+  std::string ToString() const override;
 
  private:
   PropertyMap properties_;
-  PropertyErrorMap property_errors_;
-  std::vector<std::string> request_properties_;
 };
+
+inline PropertyMapPayload* ToPropertyMapPayload(Payload* payload) {
+  if (!payload)
+     return nullptr;
+  if (payload->type() == Payload::Properties)
+    return static_cast<PropertyMapPayload*>(payload);
+  WDS_ERROR("Inappropriate payload type");
+  return nullptr;
+}
+
+class GetParameterPayload : public Payload {
+ public:
+  GetParameterPayload() : Payload(Payload::Requests) {}
+  explicit GetParameterPayload(
+      const std::vector<std::string>& properties);
+  ~GetParameterPayload() override;
+
+  void AddRequestProperty(const PropertyType& property);
+  void AddRequestProperty(const std::string& generic_property);
+  const std::vector<std::string>& properties() const {
+    return properties_;
+  }
+
+  std::string ToString() const override;
+
+ private:
+  std::vector<std::string> properties_;
+};
+
+inline GetParameterPayload* ToGetParameterPayload(Payload* payload) {
+  if (!payload)
+    return nullptr;
+  if (payload->type() == Payload::Requests)
+    return static_cast<GetParameterPayload*>(payload);
+  WDS_ERROR("Inappropriate payload type");
+  return nullptr;
+}
+
+class PropertyErrorPayload : public Payload {
+ public:
+  PropertyErrorPayload() : Payload(Payload::Errors) {}
+  ~PropertyErrorPayload() override;
+
+  std::shared_ptr<PropertyErrors> GetPropertyError(const std::string& name) const;
+  std::shared_ptr<PropertyErrors> GetPropertyError(PropertyType type) const;
+  void AddPropertyError(const std::shared_ptr<PropertyErrors>& error);
+  const PropertyErrorMap& property_errors() const { return property_errors_; }
+  std::string ToString() const override;
+
+ private:
+  PropertyErrorMap property_errors_;
+};
+
+inline PropertyErrorPayload* ToPropertyErrorPayload(Payload* payload) {
+  if (!payload)
+     return nullptr;
+  if (payload->type() == Payload::Errors)
+    return static_cast<PropertyErrorPayload*>(payload);
+  WDS_ERROR("Inappropriate payload type");
+  return nullptr;
+}
 
 }  // namespace rtsp
 }  // namespace wds

--- a/libwds/rtsp/property.cpp
+++ b/libwds/rtsp/property.cpp
@@ -43,6 +43,12 @@ std::string Property::ToString() const {
   return std::string();
 }
 
+std::string Property::GetName() const {
+  if (type_ == GenericPropertyType)
+    return std::string();
+  return GetPropertyName(type_);
+}
+
 std::string GetPropertyName(PropertyType type) {
   switch(type) {
     case AVFormatChangeTimingPropertyType:

--- a/libwds/rtsp/property.h
+++ b/libwds/rtsp/property.h
@@ -40,6 +40,8 @@ class Property {
   PropertyType type() { return type_; }
   bool is_none() const { return is_none_; }
 
+  virtual std::string GetName() const;
+
  protected:
   Property(PropertyType type, bool is_none_);
 

--- a/libwds/sink/sink.cpp
+++ b/libwds/sink/sink.cpp
@@ -49,21 +49,25 @@ bool InitializeRequestId(Request* request) {
     id = Request::M1;
     break;
   case Request::MethodGetParameter:
-    if (request->payload().get_parameter_properties().empty())
-      id = Request::M16;
-    else
-      id = Request::M3;
-    break;
+    if (auto payload = rtsp::ToGetParameterPayload(request->payload())) {
+      if (payload->properties().empty())
+        id = Request::M16;
+      else
+        id = Request::M3;
+      break;
+    }
   case Request::MethodSetParameter:
-    if (request->payload().has_property(rtsp::PresentationURLPropertyType))
-      id = Request::M4;
-    else if (request->payload().has_property(rtsp::AVFormatChangeTimingPropertyType))
-      id = Request::M4;
-    else if (request->payload().has_property(rtsp::TriggerMethodPropertyType))
-      id = Request::M5;
-    break;
+    if (auto payload = rtsp::ToPropertyMapPayload(request->payload())) {
+      if (payload->HasProperty(rtsp::PresentationURLPropertyType))
+        id = Request::M4;
+      else if (payload->HasProperty(rtsp::AVFormatChangeTimingPropertyType))
+        id = Request::M4;
+      else if (payload->HasProperty(rtsp::TriggerMethodPropertyType))
+        id = Request::M5;
+      break;
+    }
   default:
-    // TODO: warning.
+    WDS_ERROR("Failed to identify the received message");
     return false;
   }
 

--- a/libwds/sink/streaming_state.cpp
+++ b/libwds/sink/streaming_state.cpp
@@ -49,10 +49,15 @@ class M5Handler final : public MessageReceiver<Request::M5> {
   bool CanHandle(Message* message) const override {
     if (!MessageReceiver<Request::M5>::CanHandle(message))
       return false;
-
+    auto payload = ToPropertyMapPayload(message->payload());
+    if (!payload) {
+      WDS_ERROR("Failed to obtain payload in M5 handler.");
+      return false;
+    }
     auto property =
-      static_cast<TriggerMethod*>(message->payload().get_property(rtsp::TriggerMethodPropertyType).get());
-    return  method == property->method();
+        static_cast<TriggerMethod*>(
+            payload->GetProperty(rtsp::TriggerMethodPropertyType).get());
+    return method == property->method();
   }
 
   std::unique_ptr<Reply> HandleMessage(Message* message) override {

--- a/libwds/source/session_state.cpp
+++ b/libwds/source/session_state.cpp
@@ -31,6 +31,7 @@
 namespace wds {
 
 using rtsp::Message;
+using rtsp::Payload;
 using rtsp::Request;
 using rtsp::Reply;
 
@@ -44,8 +45,10 @@ class M5Handler final : public SequencedMessageSender {
   std::unique_ptr<Message> CreateMessage() override {
     rtsp::SetParameter* set_param = new rtsp::SetParameter("rtsp://localhost/wfd1.0");
     set_param->header().set_cseq(send_cseq_++);
-    set_param->payload().add_property(
+    auto payload = new rtsp::PropertyMapPayload();
+    payload->AddProperty(
         std::shared_ptr<rtsp::Property>(new rtsp::TriggerMethod(rtsp::TriggerMethod::SETUP)));
+    set_param->set_payload(std::unique_ptr<Payload>(payload));
     return std::unique_ptr<Message>(set_param);
   }
 


### PR DESCRIPTION
Split rtsp::Payload into three classes based on their contents. Payload can contain exclusively either properties or requests or errors info but not a combination of those.