### PR TITLE
Add license headers to generated files

### DIFF
--- a/libwds/rtsp/errorlexer.l
+++ b/libwds/rtsp/errorlexer.l
@@ -6,7 +6,7 @@
 %option extra-type="bool"
 %option outfile="gen/errorscanner.cpp" header-file="gen/errorscanner.h"
 
-%{
+%top{
 /*
  * This file is part of Wireless Display Software for Linux OS
  *
@@ -27,8 +27,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA
  */
+}
 
-
+%{
 #include <string>
 #include "parser.h"
 #define yyterminate() return(END)

--- a/libwds/rtsp/headerlexer.l
+++ b/libwds/rtsp/headerlexer.l
@@ -6,7 +6,7 @@
 %option extra-type="bool"
 %option outfile="gen/headerscanner.cpp" header-file="gen/headerscanner.h"
 
-%{
+%top{
 /*
  * This file is part of Wireless Display Software for Linux OS
  *
@@ -27,9 +27,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA
  */
+}
 
-
-
+%{
 #include <string>
 #include "parser.h"
 #define yyterminate() return(END)

--- a/libwds/rtsp/messagelexer.l
+++ b/libwds/rtsp/messagelexer.l
@@ -6,7 +6,7 @@
 %option extra-type="bool"
 %option outfile="gen/messagescanner.cpp" header-file="gen/messagescanner.h"
 
-%{
+%top{
 /*
  * This file is part of Wireless Display Software for Linux OS
  *
@@ -27,7 +27,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA
  */
+}
 
+%{
 #include <string>
 #include "parser.h"
 #define yyterminate() return(END)

--- a/libwds/rtsp/parser.ypp
+++ b/libwds/rtsp/parser.ypp
@@ -4,6 +4,27 @@
 %defines "gen/parser.h"
 
 %code requires {
+/*
+ * This file is part of Wireless Display Software for Linux OS
+ *
+ * Copyright (C) 2015 Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
    #include <map>
    #include <memory>
    #include "libwds/rtsp/audiocodecs.h"
@@ -37,27 +58,6 @@
 %parse-param {void* scanner} { std::unique_ptr<wds::rtsp::Message>& message }
 
 %code {
-/*
- * This file is part of Wireless Display Software for Linux OS
- *
- * Copyright (C) 2015 Intel Corporation.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA
- */
-
 #include <iostream>
 #include <cstdlib>
 #include <string>


### PR DESCRIPTION
This patch moves license information to the beginning
of the generated parser / lexer files.