### PR TITLE
Improve CSeq calculation

### DIFF
--- a/libwds/common/message_handler.cpp
+++ b/libwds/common/message_handler.cpp
@@ -30,8 +30,6 @@ using rtsp::Message;
 using rtsp::Request;
 using rtsp::Reply;
 
-int MessageHandler::send_cseq_ = 1;
-
 bool MessageHandler::HandleTimeoutEvent(uint timer_id) const {
   return false;
 }

--- a/libwds/common/message_handler.h
+++ b/libwds/common/message_handler.h
@@ -98,8 +98,6 @@ protected:
   Peer::Delegate* sender_;
   MediaManager* manager_;
   Observer* observer_;
-  // States should be handled within one thread. It's OK to have this static.
-  static int send_cseq_;
 };
 
 class MessageSequenceHandler : public MessageHandler,

--- a/libwds/public/peer.h
+++ b/libwds/public/peer.h
@@ -73,6 +73,15 @@ class Peer {
      */
     virtual void ReleaseTimer(uint timer_id) = 0;
 
+    /**
+     * Returns the sequence number for the following RTSP request-response pair
+     * @param initial_peer_cseq is provided for the WFD sink implementation at
+     * the first method's call during the WFD session and it contains the
+     * initial request sequence number obtained from the WFD source (the initial
+     * sequence numbers of connected peers may not be identical).
+     */
+    virtual int GetNextCSeq(int* initial_peer_cseq = nullptr) const = 0;
+
    protected:
     virtual ~Delegate() {}
   };

--- a/libwds/sink/init_state.cpp
+++ b/libwds/sink/init_state.cpp
@@ -32,10 +32,12 @@ using rtsp::Reply;
 
 class M1Handler final : public MessageReceiver<Request::M1> {
  public:
-  M1Handler(const InitParams& init_params)
-    : MessageReceiver<Request::M1>(init_params) {
+  M1Handler(const InitParams& init_params, int& source_init_cseq)
+    : MessageReceiver<Request::M1>(init_params),
+      source_init_cseq_(source_init_cseq) {
   }
   virtual std::unique_ptr<Reply> HandleMessage(Message* message) override {
+    source_init_cseq_ = message->cseq();
     auto reply = std::unique_ptr<Reply>(new Reply(rtsp::STATUS_OK));
     std::vector<rtsp::Method> supported_methods;
     supported_methods.push_back(rtsp::ORG_WFA_WFD_1_0);
@@ -44,15 +46,21 @@ class M1Handler final : public MessageReceiver<Request::M1> {
     reply->header().set_supported_methods(supported_methods);
     return std::move(reply);
   }
+
+ private:
+  int& source_init_cseq_;
 };
 
 class M2Handler final : public SequencedMessageSender {
  public:
-    using SequencedMessageSender::SequencedMessageSender;
+  M2Handler(const InitParams& init_params, int& source_init_cseq)
+    : SequencedMessageSender(init_params),
+      source_init_cseq_(source_init_cseq) {
+  }
  private:
   virtual std::unique_ptr<Message> CreateMessage() override {
     auto options = new rtsp::Options("*");
-    options->header().set_cseq(send_cseq_++);
+    options->header().set_cseq(sender_->GetNextCSeq(&source_init_cseq_));
     options->header().set_require_wfd_support(true);
     return std::unique_ptr<Message>(options);
   }
@@ -73,12 +81,14 @@ class M2Handler final : public SequencedMessageSender {
 
     return false;
   }
+  int& source_init_cseq_;
 };
 
 InitState::InitState(const InitParams& init_params)
-  : MessageSequenceHandler(init_params) {
-  AddSequencedHandler(make_ptr(new M1Handler(init_params)));
-  AddSequencedHandler(make_ptr(new M2Handler(init_params)));
+  : MessageSequenceHandler(init_params),
+    source_init_cseq_(0) {
+  AddSequencedHandler(make_ptr(new M1Handler(init_params, source_init_cseq_)));
+  AddSequencedHandler(make_ptr(new M2Handler(init_params, source_init_cseq_)));
 }
 
 }  // sink

--- a/libwds/sink/init_state.h
+++ b/libwds/sink/init_state.h
@@ -32,6 +32,9 @@ namespace sink {
 class InitState : public MessageSequenceHandler {
  public:
   InitState(const InitParams& init_params);
+
+ private:
+  int source_init_cseq_;
 };
 
 }  // sink

--- a/libwds/sink/session_state.cpp
+++ b/libwds/sink/session_state.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<Message> M6Handler::CreateMessage() {
   // we assume here that there is no coupled secondary sink
   transport->set_client_port(ToSinkMediaManager(manager_)->GetLocalRtpPorts().first);
   setup->header().set_transport(transport);
-  setup->header().set_cseq(send_cseq_++);
+  setup->header().set_cseq(sender_->GetNextCSeq());
   setup->header().set_require_wfd_support(true);
 
   return std::unique_ptr<Message>(setup);
@@ -88,7 +88,7 @@ class M7Handler final : public SequencedMessageSender {
   std::unique_ptr<Message> CreateMessage() override {
     rtsp::Play* play = new rtsp::Play(ToSinkMediaManager(manager_)->GetPresentationUrl());
     play->header().set_session(manager_->GetSessionId());
-    play->header().set_cseq(send_cseq_++);
+    play->header().set_cseq(sender_->GetNextCSeq());
     play->header().set_require_wfd_support(true);
 
     return std::unique_ptr<Message>(play);

--- a/libwds/sink/sink.cpp
+++ b/libwds/sink/sink.cpp
@@ -93,8 +93,6 @@ class SinkStateMachine : public MessageSequenceHandler {
    SinkStateMachine(Peer::Delegate* sender, SinkMediaManager* mng)
      : SinkStateMachine({sender, mng, this}) {}
 
-   int GetNextCSeq() { return send_cseq_++; }
-
  private:
    uint keep_alive_timer_;
 };
@@ -128,11 +126,13 @@ class SinkImpl final : public Sink, public RTSPInputHandler, public MessageHandl
   void ResetAndTeardownMedia();
 
   std::shared_ptr<SinkStateMachine> state_machine_;
+  Delegate* delegate_;
   SinkMediaManager* manager_;
 };
 
 SinkImpl::SinkImpl(Delegate* delegate, SinkMediaManager* mng)
   : state_machine_(new SinkStateMachine({delegate, mng, this})),
+    delegate_(delegate),
     manager_(mng) {
 }
 
@@ -152,7 +152,7 @@ template <class WfdMessage, Request::ID id>
 std::unique_ptr<Message> SinkImpl::CreateCommand() {
   auto message = new WfdMessage(manager_->GetPresentationUrl());
   message->header().set_session(manager_->GetSessionId());
-  message->header().set_cseq(state_machine_->GetNextCSeq());
+  message->header().set_cseq(delegate_->GetNextCSeq());
   message->set_id(id);
   return std::unique_ptr<Message>(message);
 }

--- a/libwds/sink/streaming_state.cpp
+++ b/libwds/sink/streaming_state.cpp
@@ -72,7 +72,7 @@ class M7Sender final : public SequencedMessageSender {
   std::unique_ptr<Message> CreateMessage() override {
     rtsp::Play* play = new rtsp::Play(ToSinkMediaManager(manager_)->GetPresentationUrl());
     play->header().set_session(manager_->GetSessionId());
-    play->header().set_cseq (send_cseq_++);
+    play->header().set_cseq (sender_->GetNextCSeq());
     return std::unique_ptr<Message>(play);
   }
 
@@ -101,7 +101,7 @@ class M8Sender final : public SequencedMessageSender {
   std::unique_ptr<Message> CreateMessage() override {
     rtsp::Teardown* teardown = new rtsp::Teardown(ToSinkMediaManager(manager_)->GetPresentationUrl());
     teardown->header().set_session(manager_->GetSessionId());
-    teardown->header().set_cseq(send_cseq_++);
+    teardown->header().set_cseq(sender_->GetNextCSeq());
     return std::unique_ptr<Message>(teardown);
   }
 
@@ -128,7 +128,7 @@ class M9Sender final : public SequencedMessageSender {
   std::unique_ptr<Message> CreateMessage() override {
     rtsp::Pause* pause = new rtsp::Pause(ToSinkMediaManager(manager_)->GetPresentationUrl());
     pause->header().set_session(manager_->GetSessionId());
-    pause->header().set_cseq(send_cseq_++);
+    pause->header().set_cseq(sender_->GetNextCSeq());
     return std::unique_ptr<Message>(pause);
   }
 

--- a/libwds/source/cap_negotiation_state.cpp
+++ b/libwds/source/cap_negotiation_state.cpp
@@ -66,7 +66,7 @@ class M4Handler final : public SequencedMessageSender {
 
 std::unique_ptr<Message> M3Handler::CreateMessage() {
   GetParameter* get_param = new GetParameter("rtsp://localhost/wfd1.0");
-  get_param->header().set_cseq(send_cseq_++);
+  get_param->header().set_cseq(sender_->GetNextCSeq());
   std::vector<std::string> props;
 
   SessionType media_type = ToSourceMediaManager(manager_)->GetSessionType();
@@ -133,7 +133,7 @@ bool M3Handler::HandleReply(Reply* reply) {
 
 std::unique_ptr<Message> M4Handler::CreateMessage() {
   SetParameter* set_param = new SetParameter("rtsp://localhost/wfd1.0");
-  set_param->header().set_cseq(send_cseq_++);
+  set_param->header().set_cseq(sender_->GetNextCSeq());
   SourceMediaManager* source_manager = ToSourceMediaManager(manager_);
   const auto& ports = source_manager->GetSinkRtpPorts();
   auto payload = new rtsp::PropertyMapPayload();

--- a/libwds/source/init_state.cpp
+++ b/libwds/source/init_state.cpp
@@ -38,7 +38,7 @@ class M1Handler final : public SequencedMessageSender {
  private:
   std::unique_ptr<Message> CreateMessage() override {
     rtsp::Options* options = new rtsp::Options("*");
-    options->header().set_cseq(send_cseq_++);
+    options->header().set_cseq(sender_->GetNextCSeq());
     options->header().set_require_wfd_support(true);
     return std::unique_ptr<Message>(options);
   }

--- a/libwds/source/session_state.cpp
+++ b/libwds/source/session_state.cpp
@@ -43,7 +43,7 @@ class M5Handler final : public SequencedMessageSender {
  private:
   std::unique_ptr<Message> CreateMessage() override {
     rtsp::SetParameter* set_param = new rtsp::SetParameter("rtsp://localhost/wfd1.0");
-    set_param->header().set_cseq(send_cseq_++);
+    set_param->header().set_cseq(sender_->GetNextCSeq());
     auto payload = new rtsp::PropertyMapPayload();
     payload->AddProperty(
         std::shared_ptr<rtsp::Property>(new rtsp::TriggerMethod(rtsp::TriggerMethod::SETUP)));

--- a/libwds/source/source.cpp
+++ b/libwds/source/source.cpp
@@ -96,8 +96,6 @@ class SourceStateMachine : public MessageSequenceHandler {
      AddSequencedHandler(make_ptr(new source::SessionState(init_params, timer_id, m16_sender)));
      AddSequencedHandler(make_ptr(new source::StreamingState(init_params, m16_sender)));
    }
-
-   int GetNextCSeq() { return send_cseq_++; }
 };
 
 class SourceImpl final : public Source, public RTSPInputHandler, public MessageHandler::Observer {
@@ -166,7 +164,7 @@ void SourceImpl::SendKeepAlive() {
   delegate_->ReleaseTimer(keep_alive_timer_);
   auto get_param = std::unique_ptr<Request>(
       new rtsp::GetParameter("rtsp://localhost/wfd1.0"));
-  get_param->header().set_cseq(state_machine_->GetNextCSeq());
+  get_param->header().set_cseq(delegate_->GetNextCSeq());
   get_param->set_id(Request::M16);
 
   assert(state_machine_->CanSend(get_param.get()));
@@ -193,7 +191,7 @@ std::unique_ptr<Message> CreateM5(int send_cseq, rtsp::TriggerMethod::Method met
 }
 
 bool SourceImpl::Teardown() {
-  auto m5 = CreateM5(state_machine_->GetNextCSeq(),
+  auto m5 = CreateM5(delegate_->GetNextCSeq(),
                      rtsp::TriggerMethod::TEARDOWN);
 
   if (!state_machine_->CanSend(m5.get()))
@@ -203,7 +201,7 @@ bool SourceImpl::Teardown() {
 }
 
 bool SourceImpl::Play() {
-  auto m5 = CreateM5(state_machine_->GetNextCSeq(),
+  auto m5 = CreateM5(delegate_->GetNextCSeq(),
                      rtsp::TriggerMethod::PLAY);
 
   if (!state_machine_->CanSend(m5.get()))
@@ -213,7 +211,7 @@ bool SourceImpl::Play() {
 }
 
 bool SourceImpl::Pause() {
-  auto m5 = CreateM5(state_machine_->GetNextCSeq(),
+  auto m5 = CreateM5(delegate_->GetNextCSeq(),
                      rtsp::TriggerMethod::PAUSE);
 
   if (!state_machine_->CanSend(m5.get()))

--- a/mirac_network/mirac-broker.cpp
+++ b/mirac_network/mirac-broker.cpp
@@ -276,3 +276,12 @@ void MiracBroker::ReleaseTimer(uint timer_id) {
   }
 }
 
+int MiracBroker::GetNextCSeq(int* initial_peer_cseq) const {
+  static int send_cseq_;
+  ++send_cseq_;
+  if (initial_peer_cseq && send_cseq_ == *initial_peer_cseq)
+    send_cseq_ *= 2;
+
+  return send_cseq_;
+}
+

--- a/mirac_network/mirac-broker.hpp
+++ b/mirac_network/mirac-broker.hpp
@@ -53,6 +53,7 @@ class MiracBroker : public wds::Peer::Delegate
         std::string GetLocalIPAddress() const override;
         uint CreateTimer(int seconds) override;
         void ReleaseTimer(uint timer_id) override;
+        int GetNextCSeq(int* initial_peer_cseq = nullptr) const override;
 
         virtual void got_message(const std::string& data) {}
         virtual void on_connected() {};


### PR DESCRIPTION
This patch delegates the CSeq calculation to the implementation.
Besides it consider the requirement that the initial value of
CSeq at the WFD Source and the initial value of CSeq at the WFD
Sink may not be identical.