### PR TITLE
Fixes compilation warnings

### DIFF
--- a/libwds/rtsp/property.cpp
+++ b/libwds/rtsp/property.cpp
@@ -21,7 +21,7 @@
 
 #include "libwds/rtsp/property.h"
 
-#include <cassert>
+#include "libwds/public/logging.h"
 
 namespace wds {
 namespace rtsp {
@@ -66,7 +66,7 @@ std::string GetPropertyName(PropertyType type) {
     case DisplayEdidPropertyType:
       return PropertyName::wfd_display_edid;
     case GenericPropertyType:
-      assert(!"Generic property does not have a defined name");
+      WDS_ERROR("Generic property does not have a defined name");
       return std::string();
     case I2CPropertyType:
       return PropertyName::wfd_I2C;
@@ -93,7 +93,7 @@ std::string GetPropertyName(PropertyType type) {
     case VideoFormatsPropertyType:
       return PropertyName::wfd_video_formats;
     default:
-      assert(!"Unknown property type");
+      WDS_ERROR("Unknown property type %d", type);
       return std::string();
   }
 }

--- a/libwds/rtsp/uibccapability.h
+++ b/libwds/rtsp/uibccapability.h
@@ -76,7 +76,6 @@ class UIBCCapability: public Property {
   std::vector<InputType> generic_capabilities_;
   std::vector<DetailedCapability> hidc_capabilities_;
   int tcp_port_;
-  bool has_capabilities_;
 };
 
 }  // namespace rtsp

--- a/libwds/sink/cap_negotiation_state.cpp
+++ b/libwds/sink/cap_negotiation_state.cpp
@@ -118,7 +118,7 @@ std::unique_ptr<Reply> M3Handler::HandleMessage(Message* message) {
   }
   reply->set_payload(std::unique_ptr<Payload>(reply_payload));
 
-  return std::move(reply);
+  return reply;
 }
 
 
@@ -162,7 +162,7 @@ std::unique_ptr<Reply> M4Handler::HandleMessage(Message* message) {
         std::make_shared<rtsp::PropertyErrors>(rtsp::VideoFormatsPropertyType, error_codes);
     payload->AddPropertyError(property_errors);
     reply->set_payload(std::unique_ptr<rtsp::Payload>(payload));
-    return std::move(reply);
+    return reply;
   }
 
   return std::unique_ptr<Reply>(new Reply(rtsp::STATUS_OK));
@@ -188,7 +188,7 @@ class M5Handler final : public MessageReceiver<Request::M5> {
       reply->set_response_code(rtsp::STATUS_SeeOther);
     }
 
-    return std::move(reply);
+    return reply;
   }
 };
 

--- a/libwds/sink/init_state.cpp
+++ b/libwds/sink/init_state.cpp
@@ -44,7 +44,7 @@ class M1Handler final : public MessageReceiver<Request::M1> {
     supported_methods.push_back(rtsp::GET_PARAMETER);
     supported_methods.push_back(rtsp::SET_PARAMETER);
     reply->header().set_supported_methods(supported_methods);
-    return std::move(reply);
+    return reply;
   }
 
  private:

--- a/libwds/source/init_state.cpp
+++ b/libwds/source/init_state.cpp
@@ -66,7 +66,7 @@ class M2Handler final : public MessageReceiver<Request::M2> {
     supported_methods.push_back(rtsp::SETUP);
     supported_methods.push_back(rtsp::TEARDOWN);
     reply->header().set_supported_methods(supported_methods);
-    return std::move(reply);
+    return reply;
   }
 };
 

--- a/libwds/source/session_state.cpp
+++ b/libwds/source/session_state.cpp
@@ -76,7 +76,7 @@ class M6Handler final : public MessageReceiver<Request::M6> {
     transport->set_server_port(ToSourceMediaManager(manager_)->GetLocalRtpPort());
     reply->header().set_transport(transport);
 
-    return std::move(reply);
+    return reply;
   }
 
   void Handle(std::unique_ptr<Message> message) override {


### PR DESCRIPTION
Warnings when build with Chromium toolchain
1) assert(!"text") complains on implicit type conversion
2) local values do not require std::move when returned