### PR TITLE
implement sink IDRRequest handling

### DIFF
--- a/libwds/public/media_manager.h
+++ b/libwds/public/media_manager.h
@@ -155,6 +155,8 @@ class SinkMediaManager : public MediaManager {
    * @return connector type. @see ConnectorType
    */
   virtual ConnectorType GetConnectorType() const = 0;
+
+  virtual void IDRRequestDone(bool success) = 0;
 };
 
 /**

--- a/libwds/public/sink.h
+++ b/libwds/public/sink.h
@@ -42,6 +42,8 @@ class Sink : public Peer {
    * @return newly created Sink instance
    */
   static Sink* Create(Peer::Delegate* delegate, SinkMediaManager* mng);
+
+  virtual bool IDRRequest() = 0;
 };
 
 }

--- a/libwds/sink/streaming_state.cpp
+++ b/libwds/sink/streaming_state.cpp
@@ -211,6 +211,19 @@ class M9SenderOptional final : public OptionalMessageSender<Request::M9> {
   }
 };
 
+class M13SenderOptional final : public OptionalMessageSender<Request::M13> {
+ public:
+  M13SenderOptional(const InitParams& init_params)
+    : OptionalMessageSender<Request::M13>(init_params) {
+  }
+ private:
+  bool HandleReply(Reply* reply) override {
+    bool ok = reply->response_code() == rtsp::STATUS_OK;
+    ToSinkMediaManager(manager_)->IDRRequestDone(ok);
+    return ok;
+  }
+};
+
 StreamingState::StreamingState(const InitParams& init_params, MessageHandlerPtr m16_handler)
   : MessageSequenceWithOptionalSetHandler(init_params) {
   AddSequencedHandler(make_ptr(new TeardownHandler(init_params)));
@@ -219,10 +232,11 @@ StreamingState::StreamingState(const InitParams& init_params, MessageHandlerPtr 
   AddOptionalHandler(make_ptr(new M3Handler(init_params)));
   AddOptionalHandler(make_ptr(new M4Handler(init_params)));
 
-  // optional senders that handle sending play, pause and teardown
+  // optional senders that handle sending play, pause, teardown and idr-request
   AddOptionalHandler(make_ptr(new M7SenderOptional(init_params)));
   AddOptionalHandler(make_ptr(new M8SenderOptional(init_params)));
   AddOptionalHandler(make_ptr(new M9SenderOptional(init_params)));
+  AddOptionalHandler(make_ptr(new M13SenderOptional(init_params)));
   AddOptionalHandler(m16_handler);
 }
 

--- a/sink/gst_sink_media_manager.cpp
+++ b/sink/gst_sink_media_manager.cpp
@@ -92,3 +92,6 @@ bool GstSinkMediaManager::SetOptimalVideoFormat(const wds::H264VideoFormat& opti
 wds::ConnectorType GstSinkMediaManager::GetConnectorType() const {
   return wds::ConnectorTypeNone;
 }
+
+void GstSinkMediaManager::IDRRequestDone(bool success) {
+}

--- a/sink/gst_sink_media_manager.h
+++ b/sink/gst_sink_media_manager.h
@@ -45,6 +45,7 @@ class GstSinkMediaManager : public wds::SinkMediaManager {
   wds::NativeVideoFormat GetNativeVideoFormat() const override;
   bool SetOptimalVideoFormat(const wds::H264VideoFormat& optimal_format) override;
   wds::ConnectorType GetConnectorType() const override;
+  void IDRRequestDone(bool success) override;
 
  private:
   std::string hostname_;


### PR DESCRIPTION
I've tested this with several devices. Two things should be noted:

1. some devices really don't like it if they get a IDRRequest before they replied to the last one and stop sending RTSP messages.
   I've added the IDRRequestDone() callback to be able to handle this in my application, but maybe we should prevent the second request inside libwds?

2. The default timeout is not always sufficient. I have a local hack that reimplements GetResponseTimeout() with a 30 second timeout to work around this issue. I'm not sure how to handle this correctly.