### PR TITLE
Fixes #166: add missing 'break' statements

### DIFF
--- a/desktop_source/mirac_broker_source.cpp
+++ b/desktop_source/mirac_broker_source.cpp
@@ -46,8 +46,12 @@ void MiracBrokerSource::on_connection_failure(ConnectionFailure failure) {
   switch (failure) {
       case CONNECTION_LOST:
           std::cout << "* RTSP connection lost" << std::endl;
+          break;
       case CONNECTION_TIMEOUT:
           std::cout << "* RTSP connection failed: timeout" << std::endl;
+          break;
+      default:
+          std::cout << "* RTSP connection failure" << std::endl;
   }
 }
 


### PR DESCRIPTION
Add missing 'break' statements at MiracBrokerSource::on_connection_failure.