### PR TITLE
Allow 0.0.0.0 address in a presentation url

### DIFF
--- a/libwds/common/rtsp_input_handler.cpp
+++ b/libwds/common/rtsp_input_handler.cpp
@@ -59,13 +59,7 @@ bool RTSPInputHandler::ParseHeader() {
 
   const std::string& header = rtsp_input_buffer_.substr(0, eom + delimiter_length);
   rtsp_input_buffer_.erase(0, eom + delimiter_length);
-  Driver::Parse(header, message_);
-  if (!message_) {
-    ParserErrorOccurred(rtsp_input_buffer_);
-    rtsp_input_buffer_.clear();
-    return false;
-  }
-  return true;
+  return Parse(header);
 }
 
 bool RTSPInputHandler::ParsePayload() {
@@ -81,8 +75,21 @@ bool RTSPInputHandler::ParsePayload() {
 
   const std::string& payload = rtsp_input_buffer_.substr(0, content_length);
   rtsp_input_buffer_.erase(0, content_length);
-  Driver::Parse(payload, message_);
+  if (!Parse(payload))
+    return false;
+
   MessageParsed(std::move(message_));
+  return true;
+}
+
+bool RTSPInputHandler::Parse(const std::string& input) {
+  Driver::Parse(input, message_);
+  if (!message_) {
+    ParserErrorOccurred(rtsp_input_buffer_);
+    rtsp_input_buffer_.clear();
+    return false;
+  }
+
   return true;
 }
 

--- a/libwds/common/rtsp_input_handler.h
+++ b/libwds/common/rtsp_input_handler.h
@@ -46,6 +46,7 @@ class RTSPInputHandler {
  private:
   bool ParseHeader();
   bool ParsePayload();
+  bool Parse(const std::string& input);
 
   std::string rtsp_input_buffer_;
   std::unique_ptr<rtsp::Message> message_;

--- a/libwds/rtsp/messagelexer.l
+++ b/libwds/rtsp/messagelexer.l
@@ -284,12 +284,12 @@ IPPORT [:]({DIGIT}){1,5}
   return WFD_TAG;
   }
 
-<MATCH_PRESENTATION_URL>"rtsp://"[^ \t\n]+{IPADDRESS}{IPPORT}?"/wfd1.0/streamid=0" {
+<MATCH_PRESENTATION_URL>"rtsp://"{IPADDRESS}{IPPORT}?"/wfd1.0/streamid=0" {
     yylval->sval = new std::string(yytext);
     return WFD_PRESENTATION_URL_0;
   }
 
-<MATCH_PRESENTATION_URL>"rtsp://"[^ \t\n]+{IPADDRESS}{IPPORT}?"/wfd1.0/streamid=1" {
+<MATCH_PRESENTATION_URL>"rtsp://"{IPADDRESS}{IPPORT}?"/wfd1.0/streamid=1" {
     yylval->sval = new std::string(yytext);
     return WFD_PRESENTATION_URL_1;
   }


### PR DESCRIPTION
This patch fixes lexer rule for parsing presentation url.

Fixes #170: allow 0.0.0.0 address in presentation url